### PR TITLE
fix: use $CLAUDE_PROJECT_DIR in hook commands to survive CWD drift

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -208,7 +208,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/protect-main-branch.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-main-branch.py\"",
             "timeout": 5
           }
         ]
@@ -218,7 +218,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/protect-main-branch.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-main-branch.py\"",
             "timeout": 5
           }
         ]
@@ -228,7 +228,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/snk-protect.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/snk-protect.py\"",
             "timeout": 5
           }
         ]
@@ -238,7 +238,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/snk-protect.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/snk-protect.py\"",
             "timeout": 5
           }
         ]
@@ -248,7 +248,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/claudemd-line-cap.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/claudemd-line-cap.py\"",
             "timeout": 5
           }
         ]
@@ -258,7 +258,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/claudemd-line-cap.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/claudemd-line-cap.py\"",
             "timeout": 5
           }
         ]
@@ -268,7 +268,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/pre-commit-validate.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-validate.py\"",
             "timeout": 120
           }
         ]
@@ -278,7 +278,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/pr-gate.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-gate.py\"",
             "timeout": 30
           }
         ]
@@ -288,7 +288,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/checkout-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/checkout-guard.py\"",
             "timeout": 5
           }
         ]
@@ -298,7 +298,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/review-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/review-guard.py\"",
             "timeout": 5
           }
         ]
@@ -308,7 +308,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -318,7 +318,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -328,7 +328,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -338,7 +338,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -348,7 +348,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -358,7 +358,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -368,7 +368,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/shakedown-safety.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/shakedown-safety.py\"",
             "timeout": 10
           }
         ]
@@ -380,7 +380,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/post-commit-state.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-commit-state.py\"",
             "timeout": 10
           }
         ]
@@ -391,7 +391,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/session-start-workflow.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-workflow.py\"",
             "timeout": 10
           }
         ]
@@ -403,7 +403,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/stop-hook-watchdog.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-hook-watchdog.py\"",
             "timeout": 5
           }
         ]
@@ -412,7 +412,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/session-stop-workflow.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-stop-workflow.py\"",
             "timeout": 30
           }
         ]
@@ -421,7 +421,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/shakedown-readonly-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/shakedown-readonly-guard.py\"",
             "timeout": 10
           }
         ]

--- a/tests/test_hook_paths.py
+++ b/tests/test_hook_paths.py
@@ -42,7 +42,7 @@ def test_hook_command_uses_absolute_path(event, command):
 def test_no_bare_relative_claude_hooks_path():
     with open(SETTINGS_PATH) as f:
         content = f.read()
-    matches = re.findall(r'"\\.claude/hooks/', content)
+    matches = re.findall(r'(?<!\$CLAUDE_PROJECT_DIR/)\.claude/hooks/', content)
     assert not matches, (
         f"Found bare relative .claude/hooks/ paths (without $CLAUDE_PROJECT_DIR): {matches}"
     )

--- a/tests/test_hook_paths.py
+++ b/tests/test_hook_paths.py
@@ -1,0 +1,48 @@
+"""Regression test: all hook commands in settings.json must use absolute paths.
+
+Relative paths like `.claude/hooks/foo.py` break when the bash CWD drifts
+from the project root. Every command must reference $CLAUDE_PROJECT_DIR.
+See: https://github.com/ppdsw/ppds/issues/906
+"""
+import json
+import os
+import re
+
+import pytest
+
+SETTINGS_PATH = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), os.pardir, ".claude", "settings.json")
+)
+
+
+def _collect_hook_commands():
+    with open(SETTINGS_PATH) as f:
+        settings = json.load(f)
+
+    hooks_section = settings.get("hooks", {})
+    commands = []
+    for event, entries in hooks_section.items():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                if hook.get("type") == "command":
+                    commands.append((event, hook["command"]))
+    return commands
+
+
+HOOK_COMMANDS = _collect_hook_commands()
+
+
+@pytest.mark.parametrize("event,command", HOOK_COMMANDS, ids=[c for _, c in HOOK_COMMANDS])
+def test_hook_command_uses_absolute_path(event, command):
+    assert "$CLAUDE_PROJECT_DIR" in command, (
+        f"Hook in {event} uses a relative path that breaks when CWD drifts: {command}"
+    )
+
+
+def test_no_bare_relative_claude_hooks_path():
+    with open(SETTINGS_PATH) as f:
+        content = f.read()
+    matches = re.findall(r'"\\.claude/hooks/', content)
+    assert not matches, (
+        f"Found bare relative .claude/hooks/ paths (without $CLAUDE_PROJECT_DIR): {matches}"
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -42,8 +42,8 @@ def _mock_pipeline_v8_helpers(monkeypatch):
 # AC-51: All hook commands use relative paths
 # ---------------------------------------------------------------------------
 class TestHookPaths:
-    def test_all_commands_use_relative_paths(self):
-        """AC-51: No ${CLAUDE_PROJECT_DIR} in any hook command string."""
+    def test_all_commands_use_absolute_paths(self):
+        """AC-51 (updated #906): All hook commands use $CLAUDE_PROJECT_DIR."""
         settings_path = os.path.join(REPO_ROOT, ".claude", "settings.json")
         with open(settings_path, "r") as f:
             settings = json.load(f)
@@ -53,13 +53,10 @@ class TestHookPaths:
             for matcher_entry in matchers:
                 for hook in matcher_entry.get("hooks", []):
                     cmd = hook.get("command", "")
-                    assert "CLAUDE_PROJECT_DIR" not in cmd, (
-                        f"Hook command in {event_type} still uses "
-                        f"CLAUDE_PROJECT_DIR: {cmd}"
-                    )
                     if ".claude/hooks/" in cmd:
-                        assert cmd.startswith('python ".claude/hooks/'), (
-                            f"Hook command should use relative path: {cmd}"
+                        assert "$CLAUDE_PROJECT_DIR" in cmd, (
+                            f"Hook command in {event_type} uses a relative "
+                            f"path that breaks when CWD drifts: {cmd}"
                         )
 
 
@@ -2493,8 +2490,8 @@ class TestConvergeRunsOnPassWithFindings:
 # AC-123: Hook path resolution in worktrees
 # ---------------------------------------------------------------------------
 class TestHookPathResolution:
-    def test_hooks_use_relative_paths_that_work_in_worktrees(self):
-        """AC-123: Hook commands use relative paths that resolve in worktrees."""
+    def test_hooks_use_claude_project_dir(self):
+        """AC-123 (updated #906): Hook commands use $CLAUDE_PROJECT_DIR for CWD-safe resolution."""
         settings_path = os.path.join(REPO_ROOT, ".claude", "settings.json")
         with open(settings_path, "r") as f:
             settings = json.load(f)
@@ -2505,16 +2502,14 @@ class TestHookPathResolution:
                 for hook in matcher_entry.get("hooks", []):
                     cmd = hook.get("command", "")
                     if ".claude/hooks/" in cmd:
-                        # Verify it uses a simple relative path (no env var expansion)
-                        assert "CLAUDE_PROJECT_DIR" not in cmd, (
-                            f"Hook should not use CLAUDE_PROJECT_DIR: {cmd}"
+                        assert "$CLAUDE_PROJECT_DIR" in cmd, (
+                            f"Hook should use $CLAUDE_PROJECT_DIR: {cmd}"
                         )
-                        # Verify the hook file actually exists
-                        # Extract filename from command
                         parts = cmd.split('"')
                         for part in parts:
                             if ".claude/hooks/" in part:
-                                hook_path = os.path.join(REPO_ROOT, part)
+                                rel = part.replace("$CLAUDE_PROJECT_DIR/", "")
+                                hook_path = os.path.join(REPO_ROOT, rel)
                                 assert os.path.exists(hook_path), (
                                     f"Hook file not found: {hook_path}"
                                 )


### PR DESCRIPTION
## Summary
- All 22 hook commands in `.claude/settings.json` used relative paths (`.claude/hooks/foo.py`) that break when bash CWD drifts from the project root
- Changed all hook commands to use `$CLAUDE_PROJECT_DIR/.claude/hooks/foo.py` — Claude Code sets this env var to the project root, so hooks resolve correctly regardless of CWD
- Added regression test (`tests/test_hook_paths.py`) and updated existing tests in `test_pipeline.py` that asserted the old (broken) relative path behavior

Closes #906

## Test Plan
- [x] New `test_hook_paths.py` — parametrized test verifying all 22 hook commands use `$CLAUDE_PROJECT_DIR` (23 tests)
- [x] Updated `TestHookPaths` and `TestHookPathResolution` in `test_pipeline.py` to assert absolute paths
- [x] All hook scripts still exit 0 or 2 with empty JSON input
- [x] All hook file references in settings.json resolve to existing files

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)