### PR TITLE
fix(extension): prevent Sync Deployment Settings from hanging (#893)

### DIFF
--- a/.claude/state/in-flight-issues.json
+++ b/.claude/state/in-flight-issues.json
@@ -1,41 +1,45 @@
 {
   "version": 1,
-  "updated": "2026-04-21T05:42:33Z",
+  "updated": "2026-04-24T17:12:22Z",
   "open_work": [
     {
-      "session_id": "903eedac",
-      "started": "2026-04-20T18:48:32Z",
-      "branch": "feat/shakedown-guard",
-      "worktree": ".worktrees/shakedown-guard",
-      "issues": [],
-      "areas": [
-        "src/PPDS.Cli/Services",
-        ".claude/hooks",
-        ".claude/skills/shakedown"
+      "session_id": "e8079a50",
+      "started": "2026-04-24T17:12:20Z",
+      "branch": "feat/profiles-spinner-fix",
+      "worktree": ".worktrees/profiles-spinner-fix",
+      "issues": [
+        904
       ],
-      "intent": "service-layer IShakedownGuard to close safety triad findings #6/#23/#37"
+      "areas": [
+        "extension"
+      ],
+      "intent": "Fix profiles tree infinite spinner - add RPC timeouts and error states"
     },
     {
-      "session_id": "468161f6",
-      "started": "2026-04-20T23:36:50Z",
-      "branch": "feat/pipeline-ceiling",
-      "worktree": ".worktrees/pipeline-ceiling",
-      "issues": [],
-      "areas": [
-        "pipeline"
+      "session_id": "4500f1bb",
+      "started": "2026-04-24T17:12:21Z",
+      "branch": "feat/tds-assembly-fix",
+      "worktree": ".worktrees/tds-assembly-fix",
+      "issues": [
+        889
       ],
-      "intent": "Raise HARD_CEILING to 7200s and add --max-stage-seconds override flag"
+      "areas": [
+        "cli"
+      ],
+      "intent": "Fix TDS Endpoint Microsoft.Data.SqlClient assembly not found"
     },
     {
-      "session_id": "df895c3e",
-      "started": "2026-04-21T05:42:33Z",
-      "branch": "fix/pr-monitor-push-refspec",
-      "worktree": ".worktrees/pr-monitor-push-refspec",
-      "issues": [],
-      "areas": [
-        "pr-monitor"
+      "session_id": "7d08a8f8",
+      "started": "2026-04-24T17:12:22Z",
+      "branch": "feat/sync-settings-fix",
+      "worktree": ".worktrees/sync-settings-fix",
+      "issues": [
+        893
       ],
-      "intent": "fix pr-monitor git push missing explicit refspec \u2014 causes ready-flip skip when branch name differs from upstream"
+      "areas": [
+        "extension"
+      ],
+      "intent": "Fix Sync Deployment Settings getting stuck"
     }
   ]
 }

--- a/src/PPDS.Extension/src/__tests__/daemonClient.test.ts
+++ b/src/PPDS.Extension/src/__tests__/daemonClient.test.ts
@@ -949,4 +949,43 @@ describe('DaemonClient', () => {
             await expect(unconnectedClient.restart()).resolves.not.toThrow();
         });
     });
+
+    describe('environmentVariablesSyncDeploymentSettings', () => {
+        it('should pass cancellation token to sendRequest when provided', async () => {
+            const mockResult = {
+                filePath: '/test/deployment-settings.json',
+                environmentVariables: { added: 1, removed: 0, preserved: 2 },
+                connectionReferences: { added: 0, removed: 0, preserved: 1 },
+            };
+            mockConnection.sendRequest.mockResolvedValueOnce(mockResult);
+
+            const mockToken = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+            const result = await client.environmentVariablesSyncDeploymentSettings(
+                'MySolution', '/test/file.json', undefined, mockToken as any,
+            );
+
+            expect(mockConnection.sendRequest).toHaveBeenCalledWith(
+                'environmentVariables/syncDeploymentSettings',
+                { solutionId: 'MySolution', filePath: '/test/file.json' },
+                mockToken,
+            );
+            expect(result).toEqual(mockResult);
+        });
+
+        it('should not pass token when none provided', async () => {
+            const mockResult = {
+                filePath: '/test/deployment-settings.json',
+                environmentVariables: { added: 0, removed: 0, preserved: 0 },
+                connectionReferences: { added: 0, removed: 0, preserved: 0 },
+            };
+            mockConnection.sendRequest.mockResolvedValueOnce(mockResult);
+
+            await client.environmentVariablesSyncDeploymentSettings('MySolution', '/test/file.json');
+
+            expect(mockConnection.sendRequest).toHaveBeenCalledWith(
+                'environmentVariables/syncDeploymentSettings',
+                { solutionId: 'MySolution', filePath: '/test/file.json' },
+            );
+        });
+    });
 });

--- a/src/PPDS.Extension/src/__tests__/panels/connectionReferencesPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/connectionReferencesPanel.test.ts
@@ -21,10 +21,11 @@ describe('ConnectionReferencesPanel message types', () => {
             { command: 'requestEnvironmentList' },
             { command: 'openInMaker' },
             { command: 'openFlowInMaker', url: 'https://make.powerautomate.com/environments/env1/flows/flow1/details' },
+            { command: 'syncDeploymentSettings' },
             { command: 'copyToClipboard', text: 'test' },
             { command: 'webviewError', error: 'test', stack: 'trace' },
         ];
-        expect(messages).toHaveLength(12);
+        expect(messages).toHaveLength(13);
     });
 
     it('WebviewToHost filterBySolution accepts null for "All Solutions"', () => {
@@ -58,10 +59,11 @@ describe('ConnectionReferencesPanel message types', () => {
             } },
             { command: 'analyzeResult', result: { orphanedReferences: [], orphanedFlows: [], totalReferences: 0, totalFlows: 0 } },
             { command: 'solutionListLoaded', solutions: [] },
+            { command: 'deploymentSettingsSynced', filePath: '/path/to/file.json', envVars: { added: 1, removed: 0, preserved: 2 }, connectionRefs: { added: 0, removed: 0, preserved: 1 } },
             { command: 'error', message: 'test' },
             { command: 'daemonReconnected' },
         ];
-        expect(messages).toHaveLength(8);
+        expect(messages).toHaveLength(9);
     });
 
     it('ConnectionReferenceViewDto has all required fields', () => {

--- a/src/PPDS.Extension/src/__tests__/panels/environmentVariablesPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/environmentVariablesPanel.test.ts
@@ -17,12 +17,14 @@ describe('EnvironmentVariablesPanel message types', () => {
             { command: 'filterBySolution', solutionId: 'MySolution' },
             { command: 'requestSolutionList' },
             { command: 'exportDeploymentSettings' },
+            { command: 'syncDeploymentSettings' },
+            { command: 'setIncludeInactive', includeInactive: true },
             { command: 'requestEnvironmentList' },
             { command: 'openInMaker' },
             { command: 'copyToClipboard', text: 'test' },
             { command: 'webviewError', error: 'test', stack: 'trace' },
         ];
-        expect(messages).toHaveLength(12);
+        expect(messages).toHaveLength(14);
     });
 
     it('WebviewToHost filterBySolution accepts null for "All Solutions"', () => {
@@ -55,10 +57,11 @@ describe('EnvironmentVariablesPanel message types', () => {
             { command: 'variableSaved', schemaName: 'test_var', success: true },
             { command: 'solutionListLoaded', solutions: [] },
             { command: 'deploymentSettingsExported', filePath: '/path/to/file.json' },
+            { command: 'deploymentSettingsSynced', filePath: '/path/to/file.json', envVars: { added: 1, removed: 0, preserved: 2 }, connectionRefs: { added: 0, removed: 0, preserved: 1 } },
             { command: 'error', message: 'test' },
             { command: 'daemonReconnected' },
         ];
-        expect(messages).toHaveLength(10);
+        expect(messages).toHaveLength(11);
     });
 
     it('EnvironmentVariableViewDto has all required fields', () => {

--- a/src/PPDS.Extension/src/daemonClient.ts
+++ b/src/PPDS.Extension/src/daemonClient.ts
@@ -918,12 +918,14 @@ export class DaemonClient implements vscode.Disposable {
         return result;
     }
 
-    async environmentVariablesSyncDeploymentSettings(solutionId: string, filePath: string, environmentUrl?: string): Promise<EnvironmentVariablesSyncDeploymentSettingsResponse> {
+    async environmentVariablesSyncDeploymentSettings(solutionId: string, filePath: string, environmentUrl?: string, token?: CancellationToken): Promise<EnvironmentVariablesSyncDeploymentSettingsResponse> {
         await this.ensureConnected();
         const params: Record<string, unknown> = { solutionId, filePath };
         if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
         this.log.info('Calling environmentVariables/syncDeploymentSettings...');
-        return await this.connection!.sendRequest<EnvironmentVariablesSyncDeploymentSettingsResponse>('environmentVariables/syncDeploymentSettings', params);
+        return token
+            ? await this.connection!.sendRequest<EnvironmentVariablesSyncDeploymentSettingsResponse>('environmentVariables/syncDeploymentSettings', params, token)
+            : await this.connection!.sendRequest<EnvironmentVariablesSyncDeploymentSettingsResponse>('environmentVariables/syncDeploymentSettings', params);
     }
 
     async environmentVariablesGet(schemaName: string, environmentUrl?: string): Promise<EnvironmentVariablesGetResponse> {

--- a/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
+++ b/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
@@ -320,13 +320,17 @@ export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionRefere
                     cancellable: true,
                 },
                 async (_progress, progressToken) => {
-                    progressToken.onCancellationRequested(() => cts.cancel());
-                    return this.daemon.environmentVariablesSyncDeploymentSettings(
-                        this.solutionFilter!,
-                        uri.fsPath,
-                        this.environmentUrl,
-                        cts.token,
-                    );
+                    const tokenDisposable = progressToken.onCancellationRequested(() => cts.cancel());
+                    try {
+                        return await this.daemon.environmentVariablesSyncDeploymentSettings(
+                            this.solutionFilter!,
+                            uri.fsPath,
+                            this.environmentUrl,
+                            cts.token,
+                        );
+                    } finally {
+                        tokenDisposable.dispose();
+                    }
                 },
             );
 

--- a/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
+++ b/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { CancellationTokenSource } from 'vscode-jsonrpc/node';
 
 import type { DaemonClient } from '../daemonClient.js';
 import { handleAuthError } from '../utils/errorUtils.js';
@@ -299,20 +300,34 @@ export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionRefere
             return;
         }
 
+        const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        const uri = await vscode.window.showSaveDialog({
+            defaultUri: defaultUri ? vscode.Uri.joinPath(defaultUri, 'deployment-settings.json') : undefined,
+            filters: { 'JSON Files': ['json'] },
+            title: 'Sync Deployment Settings \u2014 Save To',
+        });
+
+        if (!uri) return;
+
+        const cts = new CancellationTokenSource();
+        const timeout = setTimeout(() => cts.cancel(), 60_000);
+
         try {
-            const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
-            const uri = await vscode.window.showSaveDialog({
-                defaultUri: defaultUri ? vscode.Uri.joinPath(defaultUri, 'deployment-settings.json') : undefined,
-                filters: { 'JSON Files': ['json'] },
-                title: 'Sync Deployment Settings \u2014 Save To',
-            });
-
-            if (!uri) return;
-
-            const result = await this.daemon.environmentVariablesSyncDeploymentSettings(
-                this.solutionFilter,
-                uri.fsPath,
-                this.environmentUrl,
+            const result = await vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: 'Syncing deployment settings\u2026',
+                    cancellable: true,
+                },
+                async (_progress, progressToken) => {
+                    progressToken.onCancellationRequested(() => cts.cancel());
+                    return this.daemon.environmentVariablesSyncDeploymentSettings(
+                        this.solutionFilter!,
+                        uri.fsPath,
+                        this.environmentUrl,
+                        cts.token,
+                    );
+                },
             );
 
             this.postMessage({
@@ -322,8 +337,15 @@ export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionRefere
                 connectionRefs: result.connectionReferences,
             });
         } catch (error) {
+            if (cts.token.isCancellationRequested) {
+                this.postMessage({ command: 'error', message: 'Sync cancelled \u2014 the operation timed out or was cancelled by the user.' });
+                return;
+            }
             const msg = error instanceof Error ? error.message : String(error);
             this.postMessage({ command: 'error', message: `Sync failed: ${msg}` });
+        } finally {
+            clearTimeout(timeout);
+            cts.dispose();
         }
     }
 

--- a/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
+++ b/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
@@ -14,6 +14,8 @@ import { assertNever } from './webview/shared/assert-never.js';
 /** Default Solution GUID — always present in every environment. */
 const DEFAULT_SOLUTION_ID = 'fd140aaf-4df4-11dd-bd17-0019b9312238';
 
+const SYNC_TIMEOUT_MS = 60_000;
+
 export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionReferencesPanelWebviewToHost, ConnectionReferencesPanelHostToWebview> {
     private static instances: ConnectionReferencesPanel[] = [];
     private static nextId = 1;
@@ -310,7 +312,7 @@ export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionRefere
         if (!uri) return;
 
         const cts = new CancellationTokenSource();
-        const timeout = setTimeout(() => cts.cancel(), 60_000);
+        const timeout = setTimeout(() => cts.cancel(), SYNC_TIMEOUT_MS);
 
         try {
             const result = await vscode.window.withProgress(

--- a/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
+++ b/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { CancellationTokenSource } from 'vscode-jsonrpc/node';
 
 import type { DaemonClient } from '../daemonClient.js';
 import { handleAuthError } from '../utils/errorUtils.js';
@@ -283,21 +284,34 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
             return;
         }
 
+        const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+        const uri = await vscode.window.showSaveDialog({
+            defaultUri: defaultUri ? vscode.Uri.joinPath(defaultUri, 'deployment-settings.json') : undefined,
+            filters: { 'JSON Files': ['json'] },
+            title: 'Sync Deployment Settings — Save To',
+        });
+
+        if (!uri) return;
+
+        const cts = new CancellationTokenSource();
+        const timeout = setTimeout(() => cts.cancel(), 60_000);
+
         try {
-            // Ask the user to select a file to sync (open existing or create new)
-            const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
-            const uri = await vscode.window.showSaveDialog({
-                defaultUri: defaultUri ? vscode.Uri.joinPath(defaultUri, 'deployment-settings.json') : undefined,
-                filters: { 'JSON Files': ['json'] },
-                title: 'Sync Deployment Settings — Save To',
-            });
-
-            if (!uri) return;
-
-            const result = await this.daemon.environmentVariablesSyncDeploymentSettings(
-                this.solutionFilter,
-                uri.fsPath,
-                this.environmentUrl,
+            const result = await vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: 'Syncing deployment settings…',
+                    cancellable: true,
+                },
+                async (_progress, progressToken) => {
+                    progressToken.onCancellationRequested(() => cts.cancel());
+                    return this.daemon.environmentVariablesSyncDeploymentSettings(
+                        this.solutionFilter!,
+                        uri.fsPath,
+                        this.environmentUrl,
+                        cts.token,
+                    );
+                },
             );
 
             this.postMessage({
@@ -307,8 +321,15 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
                 connectionRefs: result.connectionReferences,
             });
         } catch (error) {
+            if (cts.token.isCancellationRequested) {
+                this.postMessage({ command: 'error', message: 'Sync cancelled — the operation timed out or was cancelled by the user.' });
+                return;
+            }
             const msg = error instanceof Error ? error.message : String(error);
             this.postMessage({ command: 'error', message: `Sync failed: ${msg}` });
+        } finally {
+            clearTimeout(timeout);
+            cts.dispose();
         }
     }
 

--- a/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
+++ b/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
@@ -11,6 +11,8 @@ import { getEnvironmentPickerHtml } from './environmentPicker.js';
 import type { EnvironmentVariablesPanelWebviewToHost, EnvironmentVariablesPanelHostToWebview } from './webview/shared/message-types.js';
 import { assertNever } from './webview/shared/assert-never.js';
 
+const SYNC_TIMEOUT_MS = 60_000;
+
 export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVariablesPanelWebviewToHost, EnvironmentVariablesPanelHostToWebview> {
     private static instances: EnvironmentVariablesPanel[] = [];
     private static nextId = 1;
@@ -294,7 +296,7 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
         if (!uri) return;
 
         const cts = new CancellationTokenSource();
-        const timeout = setTimeout(() => cts.cancel(), 60_000);
+        const timeout = setTimeout(() => cts.cancel(), SYNC_TIMEOUT_MS);
 
         try {
             const result = await vscode.window.withProgress(

--- a/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
+++ b/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
@@ -304,13 +304,17 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
                     cancellable: true,
                 },
                 async (_progress, progressToken) => {
-                    progressToken.onCancellationRequested(() => cts.cancel());
-                    return this.daemon.environmentVariablesSyncDeploymentSettings(
-                        this.solutionFilter!,
-                        uri.fsPath,
-                        this.environmentUrl,
-                        cts.token,
-                    );
+                    const tokenDisposable = progressToken.onCancellationRequested(() => cts.cancel());
+                    try {
+                        return await this.daemon.environmentVariablesSyncDeploymentSettings(
+                            this.solutionFilter!,
+                            uri.fsPath,
+                            this.environmentUrl,
+                            cts.token,
+                        );
+                    } finally {
+                        tokenDisposable.dispose();
+                    }
                 },
             );
 


### PR DESCRIPTION
## Summary
- **Root cause:** `daemonClient.environmentVariablesSyncDeploymentSettings()` didn't accept or pass a `CancellationToken` to `sendRequest`, so the RPC call could hang indefinitely with no user feedback
- **Fix:** Add 60s timeout via `CancellationTokenSource`, wrap in `vscode.window.withProgress()` with cancellable progress notification, and propagate token through daemon client to `sendRequest` — in both `EnvironmentVariablesPanel` and `ConnectionReferencesPanel`
- **Cleanup:** Properly dispose `onCancellationRequested` subscription per Constitution R3; backfill missing message type test coverage

Closes #893

## Test Plan
- [x] Daemon client tests verify token is passed to `sendRequest` when provided
- [x] Daemon client tests verify no token passed when none provided  
- [x] Message type coverage tests updated for both panels (WebviewToHost + HostToWebview)
- [x] Extension launched, both panels loaded, "Sync Settings" button visible
- [x] No runtime errors in PPDS log channel

## Verification
- [x] /gates passed (TS build, typecheck, lint, dead-code, 432 tests)
- [x] /verify completed (surfaces: extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)