### PR TITLE
fix(extension): add RPC timeouts and error states to profiles tree (#904)

### DIFF
--- a/src/PPDS.Extension/src/__tests__/views/profileTreeView.test.ts
+++ b/src/PPDS.Extension/src/__tests__/views/profileTreeView.test.ts
@@ -41,6 +41,7 @@ import {
     ProfileTreeDataProvider,
     EnvironmentTreeItem,
     ManualUrlTreeItem,
+    ErrorTreeItem,
     getProfileId,
 } from '../../views/profileTreeView.js';
 
@@ -249,13 +250,30 @@ describe('ProfileTreeDataProvider', () => {
         expect(children).toEqual([]);
     });
 
-    it('getChildren returns empty array when daemon throws', async () => {
+    it('getChildren returns ErrorTreeItem when daemon throws', async () => {
         const daemon = { authList: vi.fn().mockRejectedValue(new Error('daemon not available')) };
         const provider = new ProfileTreeDataProvider(daemon as any, makeLogChannel() as any);
 
         const children = await provider.getChildren();
 
-        expect(children).toEqual([]);
+        expect(children).toHaveLength(1);
+        expect(children[0]).toBeInstanceOf(ErrorTreeItem);
+        expect(children[0].label).toBe('Failed to load profiles — click to retry');
+    });
+
+    it('getChildren returns timeout ErrorTreeItem when authList hangs', async () => {
+        vi.useFakeTimers();
+        const daemon = { authList: vi.fn().mockReturnValue(new Promise(() => {})) };
+        const provider = new ProfileTreeDataProvider(daemon as any, makeLogChannel() as any);
+
+        const childrenPromise = provider.getChildren();
+        await vi.advanceTimersByTimeAsync(10_000);
+        const children = await childrenPromise;
+
+        expect(children).toHaveLength(1);
+        expect(children[0]).toBeInstanceOf(ErrorTreeItem);
+        expect(children[0].label).toBe('Daemon not responding — click to retry');
+        vi.useRealTimers();
     });
 
     it('refresh fires onDidChangeTreeData event', () => {

--- a/src/PPDS.Extension/src/daemonClient.ts
+++ b/src/PPDS.Extension/src/daemonClient.ts
@@ -185,13 +185,11 @@ export class RpcTimeoutError extends Error {
 }
 
 export function withRpcTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new RpcTimeoutError(label, timeoutMs)), timeoutMs);
-        promise.then(
-            value => { clearTimeout(timer); resolve(value); },
-            err => { clearTimeout(timer); reject(err as Error); },
-        );
+    let timer: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new RpcTimeoutError(label, timeoutMs)), timeoutMs);
     });
+    return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer!));
 }
 
 /**

--- a/src/PPDS.Extension/src/daemonClient.ts
+++ b/src/PPDS.Extension/src/daemonClient.ts
@@ -177,6 +177,23 @@ interface DataSourceDto {
 
 export type DaemonState = 'stopped' | 'starting' | 'ready' | 'error' | 'reconnecting';
 
+export class RpcTimeoutError extends Error {
+    constructor(label: string, timeoutMs: number) {
+        super(`${label} timed out after ${timeoutMs}ms`);
+        this.name = 'RpcTimeoutError';
+    }
+}
+
+export function withRpcTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new RpcTimeoutError(label, timeoutMs)), timeoutMs);
+        promise.then(
+            value => { clearTimeout(timer); resolve(value); },
+            err => { clearTimeout(timer); reject(err as Error); },
+        );
+    });
+}
+
 /**
  * Client for communicating with the ppds serve daemon via JSON-RPC.
  *
@@ -217,6 +234,7 @@ const RPC_QUERY_EXPLAIN = new RequestType<Record<string, unknown>, QueryExplainR
 
 export class DaemonClient implements vscode.Disposable {
     private static readonly STARTUP_TIMEOUT_MS = 30_000;
+    private static readonly CONNECT_TIMEOUT_MS = 15_000;
 
     private process: ChildProcess | null = null;
     private connection: MessageConnection | null = null;
@@ -1610,7 +1628,7 @@ export class DaemonClient implements vscode.Disposable {
                 this.connectingPromise = null;
             });
         }
-        await this.connectingPromise;
+        await withRpcTimeout(this.connectingPromise, DaemonClient.CONNECT_TIMEOUT_MS, 'ensureConnected');
     }
 
     private startHeartbeat(): void {

--- a/src/PPDS.Extension/src/profileStatusBar.ts
+++ b/src/PPDS.Extension/src/profileStatusBar.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import type { DaemonClient, DaemonState } from './daemonClient.js';
+import { withRpcTimeout } from './daemonClient.js';
 
 /**
  * Status bar item that shows the currently active authentication profile.
@@ -41,8 +42,10 @@ export class ProfileStatusBar implements vscode.Disposable {
      * Fetches the current active profile from the daemon and updates the
      * status bar text. Safe to call at any time — errors are swallowed.
      */
+    private static readonly RPC_TIMEOUT_MS = 10_000;
+
     refresh(): void {
-        void this.client.authList().then(result => {
+        void withRpcTimeout(this.client.authList(), ProfileStatusBar.RPC_TIMEOUT_MS, 'authList').then(result => {
             // activeProfile is the Name field which may be null for unnamed profiles.
             // Fall back to finding the active profile in the list by isActive flag.
             let name = result.activeProfile;

--- a/src/PPDS.Extension/src/views/profileTreeView.ts
+++ b/src/PPDS.Extension/src/views/profileTreeView.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 
 import type { DaemonClient } from '../daemonClient.js';
+import { RpcTimeoutError, withRpcTimeout } from '../daemonClient.js';
 import type { ProfileInfo } from '../types.js';
 
-type ProfileTreeElement = ProfileTreeItem | EnvironmentTreeItem | ManualUrlTreeItem;
+type ProfileTreeElement = ProfileTreeItem | EnvironmentTreeItem | ManualUrlTreeItem | ErrorTreeItem;
 
 /**
  * Tree item representing a single authentication profile.
@@ -88,6 +89,22 @@ export class ManualUrlTreeItem extends vscode.TreeItem {
     }
 }
 
+/**
+ * Tree item shown when the daemon is unreachable or an RPC call fails.
+ * Clicking it triggers a refresh to retry.
+ */
+export class ErrorTreeItem extends vscode.TreeItem {
+    constructor(message: string) {
+        super(message, vscode.TreeItemCollapsibleState.None);
+        this.iconPath = new vscode.ThemeIcon('warning');
+        this.contextValue = 'error';
+        this.command = {
+            command: 'ppds.refreshProfiles',
+            title: 'Retry',
+        };
+    }
+}
+
 function buildTooltip(profile: ProfileInfo): string {
     const lines: string[] = [];
     lines.push(`Name: ${profile.name ?? '(unnamed)'}`);
@@ -123,6 +140,7 @@ export class ProfileTreeDataProvider
     private envCache: Awaited<ReturnType<DaemonClient['envList']>> | null = null;
     private envCacheTime = 0;
     private static readonly ENV_CACHE_TTL_MS = 30_000; // 30 seconds
+    private static readonly RPC_TIMEOUT_MS = 10_000;
 
     constructor(
         private readonly daemonClient: DaemonClient,
@@ -141,7 +159,11 @@ export class ProfileTreeDataProvider
         if (this.envCache && (now - this.envCacheTime) < ProfileTreeDataProvider.ENV_CACHE_TTL_MS) {
             return this.envCache;
         }
-        const result = await this.daemonClient.envList();
+        const result = await withRpcTimeout(
+            this.daemonClient.envList(),
+            ProfileTreeDataProvider.RPC_TIMEOUT_MS,
+            'envList',
+        );
         this.envCache = result;
         this.envCacheTime = now;
         return result;
@@ -163,9 +185,13 @@ export class ProfileTreeDataProvider
         return [];
     }
 
-    private async getProfiles(): Promise<ProfileTreeItem[]> {
+    private async getProfiles(): Promise<ProfileTreeElement[]> {
         try {
-            const result = await this.daemonClient.authList();
+            const result = await withRpcTimeout(
+                this.daemonClient.authList(),
+                ProfileTreeDataProvider.RPC_TIMEOUT_MS,
+                'authList',
+            );
             void vscode.commands.executeCommand('setContext', 'ppds.daemonState', 'ready');
             void vscode.commands.executeCommand('setContext', 'ppds.profileCount', result.profiles.length);
             if (this.stateTracker) {
@@ -198,7 +224,10 @@ export class ProfileTreeDataProvider
                 this.stateTracker.daemonState = 'error';
                 this.stateTracker.profileCount = 0;
             }
-            return [];
+            const errorMsg = err instanceof RpcTimeoutError
+                ? 'Daemon not responding — click to retry'
+                : 'Failed to load profiles — click to retry';
+            return [new ErrorTreeItem(errorMsg)];
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `withRpcTimeout` utility and `RpcTimeoutError` class to `daemonClient.ts` — wraps any RPC promise with a configurable timeout
- Wrap `authList()`, `envList()`, and `ensureConnected()` calls with 10s/15s timeouts so the tree view never hangs indefinitely
- Return clickable `ErrorTreeItem` nodes (with distinct messages for timeout vs generic error) instead of an empty array when RPC fails
- Add timeout to `profileStatusBar.refresh()` to prevent it from hanging too

## Test plan
- [x] New test: `getChildren returns ErrorTreeItem when daemon throws` — verifies error state renders
- [x] New test: `getChildren returns timeout ErrorTreeItem when authList hangs` — verifies timeout with fake timers
- [x] All 431 extension unit tests pass
- [x] Typecheck and lint pass

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)