### PR TITLE
fix: remove MSYS_NO_PATHCONV from claude subprocess env (#910)

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -376,7 +376,6 @@ def run_claude(worktree_path, prompt, logger, stage, dry_run=False,
 
     start = time.time()
     env = os.environ.copy()
-    env["MSYS_NO_PATHCONV"] = "1"
     env["PPDS_PIPELINE"] = "1"
     env["CLAUDE_PROJECT_DIR"] = str(Path(worktree_path).resolve())
 

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -384,7 +384,6 @@ def run_triage(worktree, pr_number, comments, logger):
     )
 
     env = os.environ.copy()
-    env["MSYS_NO_PATHCONV"] = "1"
     env["PPDS_PIPELINE"] = "1"
     env["CLAUDE_PROJECT_DIR"] = str(Path(worktree).resolve())
 
@@ -770,7 +769,6 @@ def run_retro(worktree, logger):
         return "skipped"
 
     env = os.environ.copy()
-    env["MSYS_NO_PATHCONV"] = "1"
     env["PPDS_PIPELINE"] = "1"
     env["CLAUDE_PROJECT_DIR"] = str(Path(worktree).resolve())
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -138,6 +138,31 @@ class TestPipelineEnv:
         assert env_passed.get("PPDS_PIPELINE") == "1"
         logger.close()
 
+    def test_claude_env_excludes_msys_no_pathconv(self, tmp_path):
+        """#910: MSYS_NO_PATHCONV must not propagate to claude subprocesses.
+
+        It suppresses MSYS path conversion for hooks, causing
+        $CLAUDE_PROJECT_DIR to resolve as C:\\c\\Users\\... instead of
+        C:\\Users\\... — breaking every hook invocation.
+        """
+        import pipeline
+
+        wf_dir = tmp_path / ".workflow" / "stages"
+        wf_dir.mkdir(parents=True)
+        logger = pipeline.open_logger(str(tmp_path / ".workflow" / "pipeline.log"))
+
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+
+        with unittest.mock.patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
+            pipeline.run_claude(str(tmp_path), "test", logger, "test-stage")
+
+        env_passed = mock_popen.call_args.kwargs.get("env", {})
+        assert "MSYS_NO_PATHCONV" not in env_passed, \
+            "MSYS_NO_PATHCONV in claude env breaks hook path resolution (#910)"
+        logger.close()
+
 
 # ---------------------------------------------------------------------------
 # AC-55: Stage output goes to file

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1530,3 +1530,58 @@ class TestTriageLoopSkipsRepliedComments:
         # Round 1 + round 2 (new comment) = 2 triage calls. Round 3
         # has no unreplied comments so the loop exits.
         assert mock_triage.call_count == 2
+
+
+class TestMsysPathconvNotInherited:
+    """#910: MSYS_NO_PATHCONV must not propagate to claude subprocesses.
+
+    Setting MSYS_NO_PATHCONV=1 in the claude -p env suppresses MSYS path
+    conversion for ALL child processes, including hooks. Claude Code hooks
+    reference $CLAUDE_PROJECT_DIR which needs MSYS->Windows conversion
+    when passed to Python. Without conversion, /c/Users/... becomes
+    C:\\c\\Users\\... — a non-existent path.
+    """
+
+    def test_triage_env_excludes_msys_no_pathconv(self, tmp_path):
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        comments = [{"id": 1, "user": "g", "path": "a.py", "line": 1, "body": "fix"}]
+
+        stage_dir = os.path.join(wt, ".workflow", "stages")
+        os.makedirs(stage_dir, exist_ok=True)
+        jsonl_path = os.path.join(stage_dir, "pr-monitor-triage.jsonl")
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+
+        def fake_wait(timeout=None):
+            with open(jsonl_path, "w") as f:
+                f.write(json.dumps({"type": "result", "result": "[]"}) + "\n")
+            return 0
+
+        mock_proc.wait.side_effect = fake_wait
+
+        with patch("pr_monitor.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            pr_monitor.run_triage(wt, 42, comments, logger)
+
+        env = mock_popen.call_args[1]["env"]
+        assert "MSYS_NO_PATHCONV" not in env, \
+            "MSYS_NO_PATHCONV in claude env breaks hook path resolution (#910)"
+
+    def test_retro_env_excludes_msys_no_pathconv(self, tmp_path):
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+
+        stage_dir = os.path.join(wt, ".workflow", "stages")
+        os.makedirs(stage_dir, exist_ok=True)
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        with patch("pr_monitor.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            pr_monitor.run_retro(wt, logger)
+
+        env = mock_popen.call_args[1]["env"]
+        assert "MSYS_NO_PATHCONV" not in env, \
+            "MSYS_NO_PATHCONV in claude env breaks hook path resolution (#910)"

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1564,7 +1564,8 @@ class TestMsysPathconvNotInherited:
         with patch("pr_monitor.subprocess.Popen", return_value=mock_proc) as mock_popen:
             pr_monitor.run_triage(wt, 42, comments, logger)
 
-        env = mock_popen.call_args[1]["env"]
+        assert mock_popen.called, "subprocess.Popen was not called (check PPDS_SHAKEDOWN)"
+        env = mock_popen.call_args.kwargs.get("env", {})
         assert "MSYS_NO_PATHCONV" not in env, \
             "MSYS_NO_PATHCONV in claude env breaks hook path resolution (#910)"
 
@@ -1582,6 +1583,7 @@ class TestMsysPathconvNotInherited:
         with patch("pr_monitor.subprocess.Popen", return_value=mock_proc) as mock_popen:
             pr_monitor.run_retro(wt, logger)
 
-        env = mock_popen.call_args[1]["env"]
+        assert mock_popen.called, "subprocess.Popen was not called (check PPDS_SHAKEDOWN)"
+        env = mock_popen.call_args.kwargs.get("env", {})
         assert "MSYS_NO_PATHCONV" not in env, \
             "MSYS_NO_PATHCONV in claude env breaks hook path resolution (#910)"


### PR DESCRIPTION
## Summary

- Remove `MSYS_NO_PATHCONV=1` from the environment passed to `claude -p` subprocesses in `pr_monitor.py` (triage + retro) and `pipeline.py` (run_claude)
- This env var suppressed MSYS path conversion for ALL child processes including hooks, causing `$CLAUDE_PROJECT_DIR` (`/c/Users/...`) to resolve as `C:\c\Users\...` — a non-existent path that broke every hook invocation
- `MSYS_NO_PATHCONV` is retained for `gh` CLI calls in `pipeline.py` where it correctly prevents MSYS from mangling API path arguments

Closes #910

## Test Plan

- [x] Regression tests added for `run_triage`, `run_retro`, and `run_claude` verifying `MSYS_NO_PATHCONV` is NOT in the subprocess env
- [x] All 3 new tests confirmed failing before fix, passing after
- [x] Full test suites for `test_pr_monitor.py` (69 tests) and `test_pipeline.py` (142 tests) pass (2 pre-existing failures on main unrelated to this change)

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)