### PR TITLE
fix: auto-sync component type names and remove fabricated All Solutions (#890, #892)

### DIFF
--- a/src/PPDS.Cli/Services/Solutions/SolutionService.cs
+++ b/src/PPDS.Cli/Services/Solutions/SolutionService.cs
@@ -31,19 +31,19 @@ public class SolutionService : ISolutionService
     private readonly IComponentNameResolver _nameResolver;
     private readonly ICachedMetadataProvider _cachedMetadata;
 
+    // componenttype value 80 (Model-Driven App) is not present in the generated enum,
+    // but appears at runtime in Dataverse solutions.
+    private const int ModelDrivenAppTypeCode = 80;
+
     private static readonly Dictionary<int, string> ComponentTypeNames = BuildComponentTypeNames();
 
     private static Dictionary<int, string> BuildComponentTypeNames()
     {
-        var dict = new Dictionary<int, string>();
-
-        foreach (var value in Enum.GetValues<componenttype>())
-        {
-            dict[(int)value] = Enum.GetName(value)!;
-        }
+        var dict = Enum.GetValues<componenttype>()
+            .ToDictionary(value => (int)value, value => Enum.GetName(value)!);
 
         // Display-friendly overrides for enum names that need formatting
-        dict[80] = "Model-Driven App";
+        dict[ModelDrivenAppTypeCode] = "Model-Driven App";
         dict[(int)componenttype.Connector1] = "Connector";
 
         return dict;

--- a/src/PPDS.Cli/Services/Solutions/SolutionService.cs
+++ b/src/PPDS.Cli/Services/Solutions/SolutionService.cs
@@ -31,103 +31,23 @@ public class SolutionService : ISolutionService
     private readonly IComponentNameResolver _nameResolver;
     private readonly ICachedMetadataProvider _cachedMetadata;
 
-    /// <summary>
-    /// Component type names for common component types.
-    /// </summary>
-    private static readonly Dictionary<int, string> ComponentTypeNames = new()
+    private static readonly Dictionary<int, string> ComponentTypeNames = BuildComponentTypeNames();
+
+    private static Dictionary<int, string> BuildComponentTypeNames()
     {
-        { 1, "Entity" },
-        { 2, "Attribute" },
-        { 3, "Relationship" },
-        { 4, "AttributePicklistValue" },
-        { 5, "AttributeLookupValue" },
-        { 6, "ViewAttribute" },
-        { 7, "LocalizedLabel" },
-        { 8, "RelationshipExtraCondition" },
-        { 9, "OptionSet" },
-        { 10, "EntityRelationship" },
-        { 11, "EntityRelationshipRole" },
-        { 12, "EntityRelationshipRelationships" },
-        { 13, "ManagedProperty" },
-        { 14, "EntityKey" },
-        { 16, "Privilege" },
-        { 17, "PrivilegeObjectTypeCode" },
-        { 18, "Index" },
-        { 20, "Role" },
-        { 21, "RolePrivilege" },
-        { 22, "DisplayString" },
-        { 23, "DisplayStringMap" },
-        { 24, "Form" },
-        { 25, "Organization" },
-        { 26, "SavedQuery" },
-        { 29, "Workflow" },
-        { 31, "Report" },
-        { 32, "ReportEntity" },
-        { 33, "ReportCategory" },
-        { 34, "ReportVisibility" },
-        { 35, "Attachment" },
-        { 36, "EmailTemplate" },
-        { 37, "ContractTemplate" },
-        { 38, "KBArticleTemplate" },
-        { 39, "MailMergeTemplate" },
-        { 44, "DuplicateRule" },
-        { 45, "DuplicateRuleCondition" },
-        { 46, "EntityMap" },
-        { 47, "AttributeMap" },
-        { 48, "RibbonCommand" },
-        { 49, "RibbonContextGroup" },
-        { 50, "RibbonCustomization" },
-        { 52, "RibbonRule" },
-        { 53, "RibbonTabToCommandMap" },
-        { 55, "RibbonDiff" },
-        { 59, "SavedQueryVisualization" },
-        { 60, "SystemForm" },
-        { 61, "WebResource" },
-        { 62, "SiteMap" },
-        { 63, "ConnectionRole" },
-        { 64, "ComplexControl" },
-        { 65, "HierarchyRule" },
-        { 66, "CustomControl" },
-        { 68, "CustomControlDefaultConfig" },
-        { 70, "FieldSecurityProfile" },
-        { 71, "FieldPermission" },
-        { 80, "Model-Driven App" },
-        { 90, "PluginType" },
-        { 91, "PluginAssembly" },
-        { 92, "SDKMessageProcessingStep" },
-        { 93, "SDKMessageProcessingStepImage" },
-        { 95, "ServiceEndpoint" },
-        { 150, "RoutingRule" },
-        { 151, "RoutingRuleItem" },
-        { 152, "SLA" },
-        { 153, "SLAItem" },
-        { 154, "ConvertRule" },
-        { 155, "ConvertRuleItem" },
-        { 161, "MobileOfflineProfile" },
-        { 162, "MobileOfflineProfileItem" },
-        { 165, "SimilarityRule" },
-        { 166, "DataSourceMapping" },
-        { 201, "SDKMessage" },
-        { 202, "SDKMessageFilter" },
-        { 203, "SdkMessagePair" },
-        { 204, "SdkMessageRequest" },
-        { 205, "SdkMessageRequestField" },
-        { 206, "SdkMessageResponse" },
-        { 207, "SdkMessageResponseField" },
-        { 208, "ImportMap" },
-        { 210, "WebWizard" },
-        { 300, "CanvasApp" },
-        { 371, "Connector" },
-        { 372, "Connector" },
-        { 380, "EnvironmentVariableDefinition" },
-        { 381, "EnvironmentVariableValue" },
-        { 400, "AIProjectType" },
-        { 401, "AIProject" },
-        { 402, "AIConfiguration" },
-        { 430, "EntityAnalyticsConfiguration" },
-        { 431, "AttributeImageConfiguration" },
-        { 432, "EntityImageConfiguration" }
-    };
+        var dict = new Dictionary<int, string>();
+
+        foreach (var value in Enum.GetValues<componenttype>())
+        {
+            dict[(int)value] = Enum.GetName(value)!;
+        }
+
+        // Display-friendly overrides for enum names that need formatting
+        dict[80] = "Model-Driven App";
+        dict[(int)componenttype.Connector1] = "Connector";
+
+        return dict;
+    }
 
     /// <summary>
     /// Per-environment cache for runtime-resolved component type names.

--- a/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
@@ -370,8 +370,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
 
             Application.MainLoop.Invoke(() =>
             {
-                // Build list with "All Solutions" option at top
-                var items = new List<string> { "(All Solutions)" };
+                var items = new List<string> { "(No filter)" };
                 items.AddRange(solutions.Select(s => $"{s.FriendlyName} ({s.UniqueName})"));
 
                 var listView = new ListView(items)

--- a/src/PPDS.Extension/src/__tests__/panels/connectionReferencesPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/connectionReferencesPanel.test.ts
@@ -28,7 +28,7 @@ describe('ConnectionReferencesPanel message types', () => {
         expect(messages).toHaveLength(13);
     });
 
-    it('WebviewToHost filterBySolution accepts null for "All Solutions"', () => {
+    it('WebviewToHost filterBySolution accepts null for "(No filter)"', () => {
         const msg: ConnectionReferencesPanelWebviewToHost = {
             command: 'filterBySolution',
             solutionId: null,

--- a/src/PPDS.Extension/src/__tests__/panels/environmentVariablesPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/environmentVariablesPanel.test.ts
@@ -27,7 +27,7 @@ describe('EnvironmentVariablesPanel message types', () => {
         expect(messages).toHaveLength(14);
     });
 
-    it('WebviewToHost filterBySolution accepts null for "All Solutions"', () => {
+    it('WebviewToHost filterBySolution accepts null for "(No filter)"', () => {
         const msg: EnvironmentVariablesPanelWebviewToHost = {
             command: 'filterBySolution',
             solutionId: null,

--- a/src/PPDS.Extension/src/__tests__/panels/webview/solution-filter.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/webview/solution-filter.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('SolutionFilter (#892)', () => {
+    const source = readFileSync(
+        resolve(__dirname, '../../../panels/webview/shared/solution-filter.ts'),
+        'utf-8',
+    );
+
+    it('does not use fabricated "All Solutions" label', () => {
+        expect(source).not.toContain('All Solutions');
+    });
+
+    it('uses "(No filter)" for the unfiltered option', () => {
+        expect(source).toContain('(No filter)');
+    });
+});

--- a/src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts
@@ -13,7 +13,7 @@ interface SolutionFilterOptions {
     storageKey?: string;
     /** If provided, the filter defaults to this ID instead of null (All). */
     defaultValue?: string;
-    /** If true, the "All Solutions" option is not shown. */
+    /** If true, the "(No filter)" option is not shown. */
     hideAll?: boolean;
 }
 
@@ -83,7 +83,7 @@ export class SolutionFilter {
     private render(): void {
         let html = '<select class="solution-filter-select" title="Filter by solution">';
         if (!this.options.hideAll) {
-            html += '<option value="">' + escapeHtml('All Solutions') + '</option>';
+            html += '<option value="">' + escapeHtml('(No filter)') + '</option>';
         }
         for (const s of this.solutions) {
             const selected = s.id === this.selectedId ? ' selected' : '';

--- a/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
@@ -209,14 +209,14 @@ public class SolutionServiceTests
             BindingFlags.NonPublic | BindingFlags.Static);
         dictField.Should().NotBeNull();
 
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>;
-        dict.Should().NotBeNull();
+        var dict = dictField!.GetValue(null) as Dictionary<int, string>
+            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
 
         foreach (var value in Enum.GetValues<PPDS.Dataverse.Generated.componenttype>())
         {
             dict.Should().ContainKey((int)value,
                 $"ComponentTypeNames must contain generated enum value {value} ({(int)value})");
-            dict![(int)value].Should().NotBeNullOrWhiteSpace(
+            dict[(int)value].Should().NotBeNullOrWhiteSpace(
                 $"ComponentTypeNames[{(int)value}] must have a non-empty label");
         }
     }
@@ -228,10 +228,11 @@ public class SolutionServiceTests
         var dictField = typeof(SolutionService).GetField(
             "ComponentTypeNames",
             BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>;
+        var dict = dictField!.GetValue(null) as Dictionary<int, string>
+            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
 
         dict.Should().ContainKey(80);
-        dict![80].Should().Be("Model-Driven App");
+        dict[80].Should().Be("Model-Driven App");
     }
 
     [Fact]
@@ -241,11 +242,12 @@ public class SolutionServiceTests
         var dictField = typeof(SolutionService).GetField(
             "ComponentTypeNames",
             BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>;
+        var dict = dictField!.GetValue(null) as Dictionary<int, string>
+            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
 
         // Connector1 (372) should display as "Connector", not the auto-generated "Connector1"
         dict.Should().ContainKey(372);
-        dict![372].Should().Be("Connector");
+        dict[372].Should().Be("Connector");
     }
 
     // ─── H5: D4 fault-wrapping tests ────────────────────────────────────────────

--- a/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
@@ -200,6 +200,54 @@ public class SolutionServiceTests
         dict![typeCode].Should().Be(expectedName);
     }
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComponentTypeNames_CoversAllGeneratedEnumValues()
+    {
+        var dictField = typeof(SolutionService).GetField(
+            "ComponentTypeNames",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        dictField.Should().NotBeNull();
+
+        var dict = dictField!.GetValue(null) as Dictionary<int, string>;
+        dict.Should().NotBeNull();
+
+        foreach (var value in Enum.GetValues<PPDS.Dataverse.Generated.componenttype>())
+        {
+            dict.Should().ContainKey((int)value,
+                $"ComponentTypeNames must contain generated enum value {value} ({(int)value})");
+            dict![(int)value].Should().NotBeNullOrWhiteSpace(
+                $"ComponentTypeNames[{(int)value}] must have a non-empty label");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComponentTypeNames_IncludesModelDrivenApp()
+    {
+        var dictField = typeof(SolutionService).GetField(
+            "ComponentTypeNames",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var dict = dictField!.GetValue(null) as Dictionary<int, string>;
+
+        dict.Should().ContainKey(80);
+        dict![80].Should().Be("Model-Driven App");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComponentTypeNames_NoDuplicateEnumNameCollisions()
+    {
+        var dictField = typeof(SolutionService).GetField(
+            "ComponentTypeNames",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var dict = dictField!.GetValue(null) as Dictionary<int, string>;
+
+        // Connector1 (372) should display as "Connector", not the auto-generated "Connector1"
+        dict.Should().ContainKey(372);
+        dict![372].Should().Be("Connector");
+    }
+
     // ─── H5: D4 fault-wrapping tests ────────────────────────────────────────────
 
     private static SolutionService CreateService(IDataverseConnectionPool pool)


### PR DESCRIPTION
## Summary
- **#890**: Replace the hardcoded `ComponentTypeNames` dictionary with auto-generation from the `componenttype` enum, so new types are picked up automatically when the enum is regenerated from Dataverse. Adds display-friendly overrides for `Model-Driven App` (80) and `Connector` (372).
- **#892**: Rename the fabricated "All Solutions" dropdown entry to "(No filter)" in the extension solution filter and TUI Web Resources screen. "All Solutions" was a made-up concept — the Default Solution already represents all components in Dataverse.

Closes #890
Closes #892

## Test Plan
- [x] `ComponentTypeNames_CoversAllGeneratedEnumValues` — verifies all enum values are in the dictionary
- [x] `ComponentTypeNames_IncludesModelDrivenApp` — verifies type 80 override
- [x] `ComponentTypeNames_NoDuplicateEnumNameCollisions` — verifies Connector1 → Connector
- [x] `solution-filter.test.ts` — asserts "All Solutions" absent, "(No filter)" present
- [x] Existing `ComponentTypeNames_MatchesGeneratedEnum` theory tests still pass
- [x] Compiled webview bundles contain "(No filter)" and no "All Solutions"

## Verification
- [x] /gates passed (all .NET + TS gates green)
- [x] /verify completed (surfaces: extension, tui)

🤖 Generated with [Claude Code](https://claude.com/claude-code)