### PR TITLE
fix(extension): sync solution filter state to webview on panel open (#902)

### DIFF
--- a/src/PPDS.Extension/src/__tests__/panels/webResourcesPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/webResourcesPanel.test.ts
@@ -105,6 +105,7 @@ describe('WebResourcesPanel message types', () => {
                     totalCount: 1000,
                 },
                 { command: 'webResourcesLoadComplete', requestId: 1, totalCount: 1000 },
+                { command: 'filterState', solutionId: null, textOnly: true },
                 { command: 'loading' },
                 { command: 'error', message: 'load failed' },
                 { command: 'publishResult', count: 3 },
@@ -185,6 +186,30 @@ describe('WebResourcesPanel message types', () => {
             if (msg.command === 'publishResult') {
                 expect(msg.count).toBe(5);
                 expect(msg.error).toBeUndefined();
+            }
+        });
+
+        it('filterState synchronizes persisted filter to webview', () => {
+            const msg: WebResourcesPanelHostToWebview = {
+                command: 'filterState',
+                solutionId: '11111111-1111-1111-1111-111111111111',
+                textOnly: false,
+            };
+            if (msg.command === 'filterState') {
+                expect(msg.solutionId).toBe('11111111-1111-1111-1111-111111111111');
+                expect(msg.textOnly).toBe(false);
+            }
+        });
+
+        it('filterState accepts null solutionId for all-solutions', () => {
+            const msg: WebResourcesPanelHostToWebview = {
+                command: 'filterState',
+                solutionId: null,
+                textOnly: true,
+            };
+            if (msg.command === 'filterState') {
+                expect(msg.solutionId).toBeNull();
+                expect(msg.textOnly).toBe(true);
             }
         });
     });

--- a/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
+++ b/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
@@ -187,6 +187,7 @@ export class WebResourcesPanel extends WebviewPanelBase<WebResourcesPanelWebview
             this.fsp.registerEnvironment(this.environmentId, this.environmentUrl);
         }
         await this.loadSolutionList();
+        this.postMessage({ command: 'filterState', solutionId: this.solutionId, textOnly: this.textOnly });
         await this.loadWebResources();
     }
 
@@ -212,13 +213,20 @@ export class WebResourcesPanel extends WebviewPanelBase<WebResourcesPanelWebview
     private async loadSolutionList(): Promise<void> {
         try {
             const result = await this.daemon.solutionsList(undefined, true, this.environmentUrl);
+            const solutions = result.solutions.map(s => ({
+                id: s.id,
+                uniqueName: s.uniqueName,
+                friendlyName: s.friendlyName,
+            }));
+
+            if (this.solutionId && !solutions.find(s => s.id === this.solutionId)) {
+                this.solutionId = null;
+                void this.context.globalState.update('ppds.webResources.solutionId', null);
+            }
+
             this.postMessage({
                 command: 'solutionListLoaded',
-                solutions: result.solutions.map(s => ({
-                    id: s.id,
-                    uniqueName: s.uniqueName,
-                    friendlyName: s.friendlyName,
-                })),
+                solutions,
             });
         } catch {
             // Non-critical — solution filter will just be empty

--- a/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
+++ b/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
@@ -202,6 +202,7 @@ export class WebResourcesPanel extends WebviewPanelBase<WebResourcesPanelWebview
         // WR-23: Environment change invalidates all cached data
         this.resourceCache.clear();
         await this.loadSolutionList();
+        this.postMessage({ command: 'filterState', solutionId: this.solutionId, textOnly: this.textOnly });
         await this.loadWebResources();
     }
 
@@ -219,7 +220,7 @@ export class WebResourcesPanel extends WebviewPanelBase<WebResourcesPanelWebview
                 friendlyName: s.friendlyName,
             }));
 
-            if (this.solutionId && !solutions.find(s => s.id === this.solutionId)) {
+            if (this.solutionId && !solutions.some(s => s.id === this.solutionId)) {
                 this.solutionId = null;
                 void this.context.globalState.update('ppds.webResources.solutionId', null);
             }

--- a/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
@@ -453,6 +453,7 @@ export type WebResourcesPanelHostToWebview =
     | { command: 'webResourcesLoadComplete'; requestId: number; totalCount: number }
     | { command: 'loading' }
     | { command: 'error'; message: string }
+    | { command: 'filterState'; solutionId: string | null; textOnly: boolean }
     | { command: 'publishResult'; count: number; error?: string }
     | { command: 'daemonReconnected' };
 

--- a/src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts
@@ -59,6 +59,13 @@ export class SolutionFilter {
         return this.selectedId;
     }
 
+    setSelectedId(id: string | null): void {
+        if (id === this.selectedId) return;
+        this.selectedId = id;
+        this.persist();
+        this.render();
+    }
+
     /**
      * Update the storage key suffix for per-environment persistence (CR-09).
      * Call this when the environment changes, before setSolutions().

--- a/src/PPDS.Extension/src/panels/webview/web-resources-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/web-resources-panel.ts
@@ -346,6 +346,10 @@ window.addEventListener('message', (event: MessageEvent<WebResourcesPanelHostToW
             // Re-render status bar and hide the server-search banner if showing
             applySearchFilter();
             break;
+        case 'filterState':
+            solutionFilter.setSelectedId(msg.solutionId);
+            textOnlyCb.checked = msg.textOnly;
+            break;
         case 'loading':
             content.innerHTML = '<div class="loading-state"><div class="spinner"></div><div>Loading web resources...</div></div>';
             statusText.textContent = 'Loading...';


### PR DESCRIPTION
## Summary
- Fix web resources missing from extension panel due to stale solution filter persisted in globalState but not synced to the webview's SolutionFilter dropdown on panel reopen
- Add `filterState` host-to-webview message sent on both `onInitialized` and `onEnvironmentChanged` to synchronize the solution dropdown and text-only checkbox with the host's persisted state
- Validate persisted `solutionId` against loaded solution list and clear orphaned filters gracefully

Closes #902

## Test Plan
- [x] Extension unit tests pass (435/435) — new `filterState` message type tests added
- [x] .NET unit tests pass (3302/3302 × 3 TFWs)
- [x] TypeScript compiles (host + webview tsconfigs)
- [x] Lint clean (0 errors)
- [x] Visual verification: panel loads with correct filter state, 20K+ resources displayed
- [ ] Manual test: set a solution filter, close panel, reopen — filter should be correctly shown in dropdown

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)