### PR TITLE
fix(extension): fix import jobs double-open, trace toggle feedback, active/all clarity

### DIFF
--- a/src/PPDS.Extension/src/__tests__/panels/importJobsPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/importJobsPanel.test.ts
@@ -11,7 +11,7 @@ describe('ImportJobsPanel message types', () => {
         const messages: ImportJobsPanelWebviewToHost[] = [
             { command: 'ready' },
             { command: 'refresh' },
-            { command: 'selectJob', id: 'test-id' },
+            { command: 'viewImportLog', id: 'test-id' },
             { command: 'requestEnvironmentList' },
             { command: 'openInMaker' },
             { command: 'copyToClipboard', text: 'test' },
@@ -20,16 +20,21 @@ describe('ImportJobsPanel message types', () => {
         expect(messages).toHaveLength(7);
     });
 
+    it('viewImportLog is the only command for opening import logs (#891)', () => {
+        const msg: ImportJobsPanelWebviewToHost = { command: 'viewImportLog', id: 'job-1' };
+        expect(msg.command).toBe('viewImportLog');
+        expect(msg.id).toBe('job-1');
+    });
+
     it('HostToWebview covers all commands', () => {
         const messages: ImportJobsPanelHostToWebview[] = [
             { command: 'updateEnvironment', name: 'test', envType: null, envColor: null },
-            { command: 'importJobsLoaded', jobs: [] },
-            { command: 'importJobDetailLoaded', id: 'test', data: null },
+            { command: 'importJobsLoaded', jobs: [], totalCount: 0 },
             { command: 'loading' },
             { command: 'error', message: 'test' },
             { command: 'daemonReconnected' },
         ];
-        expect(messages).toHaveLength(6);
+        expect(messages).toHaveLength(5);
     });
 
     it('ImportJobViewDto has all required fields', () => {

--- a/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
+++ b/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
@@ -398,9 +398,9 @@ export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionRefere
     <vscode-button id="sync-btn" appearance="secondary" title="Sync deployment settings for connection references">Sync Deployment Settings</vscode-button>
     <vscode-button id="maker-btn" appearance="secondary" title="Open Connections in Maker Portal">Maker Portal</vscode-button>
     <div id="solution-filter-container" class="solution-filter-container"></div>
-    <div class="toolbar-segmented" id="inactive-toggle" title="Toggle active/all connection references">
-        <button class="seg-btn seg-active" id="seg-active" data-value="active">Active Only</button>
-        <button class="seg-btn" id="seg-all" data-value="all">All</button>
+    <div class="toolbar-segmented" id="inactive-toggle" title="Active = enabled in Dataverse (statecode 0). 'All' includes deactivated references.">
+        <button class="seg-btn seg-active" id="seg-active" data-value="active" title="Show only enabled connection references">Active Only</button>
+        <button class="seg-btn" id="seg-all" data-value="all" title="Include deactivated connection references">All</button>
     </div>
     <input id="search-input" type="text" placeholder="Search connection references..." class="toolbar-search" />
     <span class="toolbar-spacer"></span>

--- a/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
+++ b/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
@@ -399,7 +399,7 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
     <vscode-button id="sync-btn" appearance="secondary" title="Sync deployment settings">Sync Settings</vscode-button>
     <vscode-button id="maker-btn" appearance="secondary" title="Open Environment Variables in Maker Portal">Maker Portal</vscode-button>
     <div id="solution-filter-container" class="solution-filter-container"></div>
-    <div class="toolbar-toggle" id="inactive-toggle" title="Toggle active/inactive variables">
+    <div class="toolbar-toggle" id="inactive-toggle" title="Active = enabled in Dataverse (statecode 0). Toggle to include deactivated variables.">
         <span id="inactive-toggle-label">Active Only</span>
     </div>
     <input id="search-input" type="text" placeholder="Search variables..." class="toolbar-search" />

--- a/src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts
@@ -51,6 +51,9 @@ inactiveToggle.addEventListener('click', () => {
     includeInactive = !includeInactive;
     inactiveToggleLabel.textContent = includeInactive ? 'All' : 'Active Only';
     inactiveToggle.classList.toggle('active', includeInactive);
+    inactiveToggle.title = includeInactive
+        ? 'Showing all variables including deactivated. Click to show active only.'
+        : 'Active = enabled in Dataverse (statecode 0). Toggle to include deactivated variables.';
     vscode.postMessage({ command: 'setIncludeInactive', includeInactive });
 });
 

--- a/src/PPDS.Extension/src/panels/webview/import-jobs-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/import-jobs-panel.ts
@@ -120,16 +120,12 @@ const table = new DataTable<ImportJobViewDto>({
     emptyMessage: 'No import jobs found',
 });
 
-// ── Solution link click handler (IJ-01): delegated on content ──
+// ── Solution link default prevention (IJ-01) ──
+// Row click (onRowClick) already sends viewImportLog; this handler only
+// prevents the browser from following the anchor's href="#".
 content.addEventListener('click', (e) => {
     const link = (e.target as HTMLElement).closest<HTMLElement>('a.solution-link');
-    if (!link) return;
-    e.preventDefault();
-    e.stopPropagation();
-    const id = link.dataset['id'];
-    if (id) {
-        vscode.postMessage({ command: 'viewImportLog', id });
-    }
+    if (link) e.preventDefault();
 });
 
 // ── Button handlers ──

--- a/src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts
@@ -1225,8 +1225,24 @@ traceLevelBtn.addEventListener('click', () => {
 traceLevelDropdown.addEventListener('click', (e) => {
     const target = (e.target as HTMLElement).closest<HTMLElement>('.trace-level-dropdown-item');
     if (target?.dataset.level) {
+        const level = target.dataset.level;
         traceLevelDropdown.style.display = 'none';
-        vscode.postMessage({ command: 'setTraceLevel', level: target.dataset.level });
+
+        // Optimistic UI update — show the new level immediately so the user
+        // gets instant feedback while the host round-trips to Dataverse.
+        traceLevelBtn.textContent = 'Trace Level: ' + level;
+        traceLevelIndicator.textContent = level;
+        traceLevelIndicator.className = level === 'Off'
+            ? 'trace-level-indicator trace-level-off'
+            : 'trace-level-indicator trace-level-on';
+        traceLevelIndicator.title = level === 'Off'
+            ? 'Trace level is Off — no new traces will be recorded'
+            : 'Trace level: ' + level;
+        traceLevelDropdown.querySelectorAll<HTMLElement>('.trace-level-dropdown-item').forEach(item => {
+            item.classList.toggle('active', item.dataset.level === level);
+        });
+
+        vscode.postMessage({ command: 'setTraceLevel', level });
     }
 });
 


### PR DESCRIPTION
## Summary
- **#891 Import Jobs double-open**: Solution link click handler and DataTable row click handler both sent `viewImportLog`, opening two XML tabs. Removed the duplicate message from the solution link handler (row click already handles it).
- **#895 Plugin Traces toggle feedback**: Added optimistic UI update when selecting a trace level — button text, indicator badge, and dropdown active state update immediately instead of waiting for the Dataverse round-trip.
- **#894 Active/All toggle clarity**: Added descriptive tooltips to Environment Variables and Connection References toggle controls explaining that "Active" = enabled in Dataverse (statecode 0) and what "All" includes. Tooltip updates dynamically on toggle for Environment Variables.

Also fixes stale test data in `importJobsPanel.test.ts` (`selectJob` → `viewImportLog`, missing `totalCount`).

Closes #891, closes #895, closes #894

## Test plan
- [ ] Import Jobs: click a solution name link → verify exactly one XML tab opens (not two)
- [ ] Plugin Traces: toggle trace level via dropdown → verify button and indicator update immediately
- [ ] Environment Variables: hover the Active Only toggle → verify tooltip explains meaning
- [ ] Connection References: hover Active Only / All buttons → verify tooltips explain meaning
- [ ] Environment Variables: toggle to All → verify tooltip updates to reflect current state
- [ ] All panels: verify no regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)