### PR TITLE
feat: release cycle — triggering, targeting, branching, enforcement

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -327,6 +327,124 @@ code --install-extension JoshSmithXRM.power-platform-developer-suite  # stable
 # Then open VS Code and verify the sidebar loads, the version matches, basic commands work
 ```
 
+## Patch Release Procedure
+
+For a single-package patch (the common case — one bug fix or security fix in one package),
+the full ceremony above is unnecessary. Use this abbreviated single-package flow instead. See
+`specs/release-cycle.md` for the policy that decides when a `release:patch` label warrants a
+patch release.
+
+**When to use:**
+
+- Exactly one package is affected (e.g., a bug in `PPDS.Query` only)
+- The change is a bug fix or security fix — not a feature
+- The merged PR is labeled `release:patch`
+
+For multi-package patches, or any patch that touches the Extension, fall back to the full
+ceremony above.
+
+**Steps (abbreviated):**
+
+1. Identify the affected package from the merged PR'"'"'s changed paths (the
+   `post-merge-release-check.yml` workflow does this automatically and opens an issue).
+2. Update **only that package'"'"'s CHANGELOG** — add a new `[X.Y.Z] - YYYY-MM-DD` entry under
+   `[Unreleased]`. Do not touch the other 7 CHANGELOGs.
+3. Open a tiny CHANGELOG-only PR, merge it, then pull main.
+4. Push **one tag** for the affected package only:
+   ```bash
+   git tag <Prefix>-v<X.Y.Z>
+   git push origin "refs/tags/<Prefix>-v<X.Y.Z>"
+   ```
+5. Monitor the **single** `publish-nuget.yml` workflow run that fires for that tag.
+6. Verify the publish on NuGet.org (see Section 10 above for the verification commands).
+
+**No release PR is required for single-package patches** — the original fix PR is the audit
+trail. The CHANGELOG-only PR in step 3 provides the version-bump record.
+
+**Cross-reference:** for multi-package patches (rare) or any patch touching the Extension,
+follow the full ceremony in Sections 1–10 above. The abbreviated flow only applies when the
+blast radius is a single NuGet package.
+
+## Stabilization Branch
+
+Stabilization branches (`release/X.Y`) are an **escape hatch** — used only when active
+development for the next minor (`X.(Y+1)`) has started on `main` before `X.Y` has been
+verified and shipped. For a solo maintainer this should be the rare exception, not the
+default. The default is to tag from `main`.
+
+**When to create one:**
+
+- A milestone (`vX.Y.0`) is feature-complete on `main` but you need to keep merging
+  unrelated work for `vX.(Y+1).0` before the `vX.Y.0` release is verified
+- A stable release is soaking and you want to land bug fixes for it without freezing `main`
+
+**When NOT to create one:**
+
+- The common case: tag directly from `main`. No branch, no merge-back overhead.
+- Patches: use the abbreviated patch flow above instead.
+
+**How to create one:**
+
+```bash
+git checkout main && git pull
+git checkout -b release/X.Y main
+git push -u origin release/X.Y
+```
+
+Create the branch at the commit where the milestone is feature-complete — typically the
+merge commit of the last issue/PR in the milestone.
+
+**What goes on it:**
+
+- **Cherry-pick bug fixes only.** No new features, no refactors. Each cherry-pick should
+  reference the original commit on `main`:
+  ```bash
+  git checkout release/X.Y
+  git cherry-pick -x <commit-sha-from-main>
+  git push origin release/X.Y
+  ```
+- The `-x` flag preserves the original commit hash in the message — critical for the
+  merge-back step below.
+
+**How to tag from it:**
+
+Tags push from the stabilization branch, **not** from `main`:
+
+```bash
+git checkout release/X.Y
+git pull
+git tag <Prefix>-v<X.Y.Z>
+git push origin "refs/tags/<Prefix>-v<X.Y.Z>"
+```
+
+The CI publish workflows fire from the tag — they don'"'"'t care which branch it points to.
+
+**How to merge back to main:**
+
+After the release publishes, merge the stabilization branch back into `main` so any
+fixes that were cherry-picked don'"'"'t drift:
+
+```bash
+git checkout main && git pull
+git merge --no-ff release/X.Y -m "merge: release/X.Y back into main after vX.Y.Z"
+# Resolve conflicts manually — favor main'"'"'s version for files that diverged
+git push origin main
+```
+
+If every commit on `release/X.Y` was cherry-picked from `main`, the merge is empty and you
+can simply delete the branch. If divergence happened (rare — usually only happens when a
+bug was fixed on the branch first and never on main), resolve conflicts case-by-case.
+
+**Cleanup:**
+
+```bash
+# Once main has all the fixes:
+git branch -d release/X.Y
+git push origin :release/X.Y
+```
+
+Do not keep stabilization branches around indefinitely — they'"'"'re intentionally short-lived.
+
 ## Known Gotchas
 
 ### Gotcha 1: `release-cli.yml` fails with HTTP 422 "tag_name was used by an immutable release"

--- a/.claude/state/in-flight-issues.json
+++ b/.claude/state/in-flight-issues.json
@@ -40,6 +40,18 @@
         "extension"
       ],
       "intent": "Fix Sync Deployment Settings getting stuck"
+  "updated": "2026-04-24T18:26:11Z",
+  "open_work": [
+    {
+      "session_id": "dd8f64eb",
+      "started": "2026-04-24T18:26:11Z",
+      "branch": "feat/release-cycle-design",
+      "worktree": ".worktrees/release-cycle-design",
+      "issues": [],
+      "areas": [
+        "release"
+      ],
+      "intent": "Design release cycle workflow: triggering, milestone targeting, branching policy, enforcement gaps"
     }
   ]
 }

--- a/.github/workflows/milestone-release-check.yml
+++ b/.github/workflows/milestone-release-check.yml
@@ -1,0 +1,65 @@
+name: Milestone Release Check
+
+on:
+  milestone:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  check-milestone-completion:
+    name: Check milestone completion and open release issue
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Query merged PRs for milestone
+        env:
+          MILESTONE_TITLE: ${{ github.event.milestone.title }}
+        run: |
+          gh pr list \
+            --state merged \
+            --json number,title \
+            --search "milestone:\"$MILESTONE_TITLE\"" \
+            > merged_prs.json
+
+      - name: Run milestone completion check
+        id: completion_check
+        env:
+          MILESTONE_TITLE: ${{ github.event.milestone.title }}
+          MILESTONE_DESC: ${{ github.event.milestone.description }}
+        run: |
+          python scripts/ci/check_milestone_completion.py \
+            --milestone "$MILESTONE_TITLE" \
+            --description "$MILESTONE_DESC" \
+            --merged-prs merged_prs.json \
+            --out issue_body.md || true
+
+          if [ -s issue_body.md ]; then
+            echo "should_open_issue=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_open_issue=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open release readiness issue
+        if: steps.completion_check.outputs.should_open_issue == 'true'
+        env:
+          MILESTONE_TITLE: ${{ github.event.milestone.title }}
+        run: |
+          gh issue create \
+            --title "Milestone $MILESTONE_TITLE complete — ready for release" \
+            --body-file issue_body.md \
+            --label "release:minor"

--- a/.github/workflows/post-merge-release-check.yml
+++ b/.github/workflows/post-merge-release-check.yml
@@ -1,0 +1,149 @@
+name: Post-Merge Release Check
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  patch-release-detection:
+    name: Detect patch release need
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release:patch')
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Get changed files
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} --name-only > changed_files.txt
+          echo "Changed files:"
+          cat changed_files.txt
+
+      - name: Map files to packages
+        run: |
+          python scripts/ci/map_files_to_packages.py < changed_files.txt > packages.json
+          echo "Affected packages:"
+          cat packages.json
+
+      - name: Evaluate packages and set warning
+        id: evaluate
+        run: |
+          python - <<'EOF'
+          import json, os
+
+          packages = json.load(open("packages.json"))
+
+          if packages == ["unknown"]:
+              warning = "No recognized PPDS package paths found — triage manually"
+          else:
+              warning = ""
+
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              f.write(f"AFFECTED_PACKAGES={json.dumps(packages)}\n")
+              f.write(f"WARNING={warning}\n")
+              # Comma-separated package list for the issue title
+              if packages == ["unknown"]:
+                  f.write("PACKAGES_DISPLAY=unknown\n")
+              else:
+                  f.write(f"PACKAGES_DISPLAY={', '.join(packages)}\n")
+          EOF
+
+      - name: Resolve latest tags per package
+        id: tags
+        run: |
+          python - <<'EOF'
+          import json, subprocess, os
+
+          packages = json.loads(os.environ["AFFECTED_PACKAGES"])
+
+          tag_lines = []
+          if packages != ["unknown"]:
+              for pkg in packages:
+                  # e.g. PPDS.Query -> prefix Query-v*
+                  prefix = pkg.split(".", 1)[1]  # strip "PPDS."
+                  result = subprocess.run(
+                      ["git", "tag", "--list", f"{prefix}-v*", "--sort=-v:refname"],
+                      capture_output=True, text=True,
+                  )
+                  tags = [t.strip() for t in result.stdout.splitlines() if t.strip()]
+                  latest = tags[0] if tags else "(no tag found)"
+                  tag_lines.append(f"- **{pkg}**: current tag → `{latest}`")
+
+          tag_summary = "\n".join(tag_lines) if tag_lines else "- No recognized packages; tag lookup skipped."
+
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              # Multiline env var via delimiter
+              delimiter = "EOF_TAGS"
+              f.write(f"TAG_SUMMARY<<{delimiter}\n{tag_summary}\n{delimiter}\n")
+          EOF
+
+      - name: Build package bullet list
+        run: |
+          python - <<'EOF'
+          import json, os
+
+          packages = json.loads(os.environ["AFFECTED_PACKAGES"])
+          if packages == ["unknown"]:
+              bullets = "- unknown (no recognized src/PPDS.* paths)"
+          else:
+              bullets = "\n".join(f"- {p}" for p in packages)
+
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              delimiter = "EOF_BULLETS"
+              f.write(f"PACKAGE_BULLETS<<{delimiter}\n{bullets}\n{delimiter}\n")
+          EOF
+
+      - name: Create patch release issue
+        run: |
+          WARNING_SECTION=""
+          if [ -n "$WARNING" ]; then
+            WARNING_SECTION="
+          > [!WARNING]
+          > $WARNING"
+          fi
+
+          gh issue create \
+            --title "Patch release needed: $PACKAGES_DISPLAY" \
+            --label "release:patch" \
+            --body "## Patch Release Needed
+
+          A PR labeled \`release:patch\` has merged to main and requires a patch release.
+
+          **Merged PR:** ${{ github.event.pull_request.html_url }}
+          **PR Title:** ${{ github.event.pull_request.title }}
+          ${WARNING_SECTION}
+
+          ### Affected Package(s)
+
+          ${PACKAGE_BULLETS}
+
+          ### Latest Tags (current → maintainer picks next patch)
+
+          ${TAG_SUMMARY}
+
+          ### Release Checklist
+
+          - [ ] Update CHANGELOG for affected package(s)
+          - [ ] Push tag(s) (e.g., \`Query-v1.0.1\`)
+          - [ ] Verify NuGet/Marketplace publish succeeds
+          - [ ] Close this issue
+
+          > **Procedure:** Follow the [Patch Release Procedure](.claude/skills/release/SKILL.md#patch-release-procedure) in the \`/release\` skill."

--- a/.github/workflows/release-cadence-check.yml
+++ b/.github/workflows/release-cadence-check.yml
@@ -1,0 +1,115 @@
+name: Release Cadence Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 09:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cadence-check:
+    name: Check release cadence
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout main (full history)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Get latest release tag and date
+        id: tag-info
+        run: |
+          LAST_TAG=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags/ | head -1)
+          LAST_TAG_DATE=$(git for-each-ref --sort=-creatordate --format='%(creatordate:iso-strict)' refs/tags/ | head -1)
+
+          if [ -z "$LAST_TAG" ]; then
+            echo "No release tags found; skipping cadence check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+            echo "last_tag_date=${LAST_TAG_DATE}" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Count unreleased commits since last tag
+        id: commits
+        if: steps.tag-info.outputs.skip == 'false'
+        run: |
+          LAST_TAG="${{ steps.tag-info.outputs.last_tag }}"
+          UNRELEASED=$(git rev-list "${LAST_TAG}..HEAD" --count)
+          echo "unreleased=${UNRELEASED}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing open cadence-check issue
+        id: open-issue
+        if: steps.tag-info.outputs.skip == 'false'
+        run: |
+          OPEN_COUNT=$(gh issue list --label "release:cadence-check" --state open --json number | jq 'length')
+          echo "open_count=${OPEN_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate cadence
+        id: evaluate
+        if: steps.tag-info.outputs.skip == 'false'
+        run: |
+          HAS_OPEN=""
+          if [ "${{ steps.open-issue.outputs.open_count }}" -gt "0" ]; then
+            HAS_OPEN="--has-open-check-in-issue"
+          fi
+
+          RESULT=$(python scripts/ci/check_release_cadence.py \
+            --last-release-date "${{ steps.tag-info.outputs.last_tag_date }}" \
+            --unreleased-commits "${{ steps.commits.outputs.unreleased }}" \
+            --last-release-tag   "${{ steps.tag-info.outputs.last_tag }}" \
+            ${HAS_OPEN})
+
+          echo "result=${RESULT}" >> "$GITHUB_OUTPUT"
+          echo "should_open=$(echo "${RESULT}" | jq -r '.should_open_issue')" >> "$GITHUB_OUTPUT"
+          echo "weeks=$(echo "${RESULT}" | jq -r '.weeks_since_release')" >> "$GITHUB_OUTPUT"
+          echo "commits=$(echo "${RESULT}" | jq -r '.unreleased_commits')" >> "$GITHUB_OUTPUT"
+          echo "reason=$(echo "${RESULT}" | jq -r '.reason')" >> "$GITHUB_OUTPUT"
+
+      - name: Open cadence check-in issue
+        if: >-
+          steps.tag-info.outputs.skip == 'false' &&
+          steps.evaluate.outputs.should_open == 'true'
+        run: |
+          WEEKS="${{ steps.evaluate.outputs.weeks }}"
+          COMMITS="${{ steps.evaluate.outputs.commits }}"
+          LAST_TAG="${{ steps.tag-info.outputs.last_tag }}"
+
+          TITLE=$(python scripts/ci/check_release_cadence.py \
+            --last-release-date "${{ steps.tag-info.outputs.last_tag_date }}" \
+            --unreleased-commits "${{ steps.commits.outputs.unreleased }}" \
+            --last-release-tag   "${LAST_TAG}" \
+            --format title)
+
+          BODY=$(python scripts/ci/check_release_cadence.py \
+            --last-release-date "${{ steps.tag-info.outputs.last_tag_date }}" \
+            --unreleased-commits "${{ steps.commits.outputs.unreleased }}" \
+            --last-release-tag   "${LAST_TAG}" \
+            --format body)
+
+          gh issue create \
+            --title "${TITLE}" \
+            --body  "${BODY}" \
+            --label "release:cadence-check"
+
+      - name: Log decision (no issue opened)
+        if: >-
+          steps.tag-info.outputs.skip == 'false' &&
+          steps.evaluate.outputs.should_open != 'true'
+        run: |
+          echo "No issue opened. Reason: ${{ steps.evaluate.outputs.reason }}"
+          echo "Weeks since release: ${{ steps.evaluate.outputs.weeks }}"
+          echo "Unreleased commits: ${{ steps.evaluate.outputs.commits }}"

--- a/scripts/ci/check_milestone_completion.py
+++ b/scripts/ci/check_milestone_completion.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Milestone completion detection for the PPDS release cycle.
+
+When a GitHub Milestone is closed, this script determines whether a release
+issue should be opened.  It is invoked by ``milestone-release-check.yml`` and
+is designed to be fully testable without GitHub Actions.
+
+Public API (called by the workflow and by unit tests):
+    should_open_release_issue(merged_prs) -> bool
+    build_issue_body(milestone_title, milestone_description, merged_prs, deferred_count) -> str
+
+CLI usage:
+    python scripts/ci/check_milestone_completion.py \\
+        --milestone "v1.1.0" \\
+        --description "First minor release" \\
+        --merged-prs merged_prs.json \\
+        [--deferred-count 2] \\
+        [--out issue_body.md]
+
+Exit codes:
+    0 — success (issue body written to stdout/file, or nothing written if no issue needed)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def should_open_release_issue(merged_prs: list[dict]) -> bool:
+    """Return True if a release issue should be opened.
+
+    An issue is warranted only when the milestone contained at least one
+    merged PR.  A milestone closed with zero merged PRs was likely deferred
+    entirely; no release action is needed.
+
+    Args:
+        merged_prs: List of dicts with at least ``number`` and ``title`` keys.
+
+    Returns:
+        True if len(merged_prs) > 0, else False.
+    """
+    return len(merged_prs) > 0
+
+
+def build_issue_body(
+    milestone_title: str,
+    milestone_description: str,
+    merged_prs: list[dict],
+    deferred_count: int = 0,
+) -> str:
+    """Build the markdown body for the GitHub release readiness issue.
+
+    Args:
+        milestone_title: The milestone name, e.g. "v1.1.0".
+        milestone_description: The milestone description text (may be empty).
+        merged_prs: List of dicts with ``number`` and ``title`` keys.
+        deferred_count: Number of issues/PRs that were deferred (moved out).
+
+    Returns:
+        A markdown string suitable for use as a GitHub issue body.
+    """
+    lines: list[str] = []
+
+    lines.append(f"## Milestone {milestone_title} — Release Readiness")
+    lines.append("")
+
+    if milestone_description:
+        lines.append(milestone_description)
+        lines.append("")
+
+    lines.append(f"### Merged PRs ({len(merged_prs)})")
+    lines.append("")
+    for pr in merged_prs:
+        number = pr.get("number", "?")
+        title = pr.get("title", "")
+        lines.append(f"- #{number} — {title}")
+    lines.append("")
+
+    if deferred_count > 0:
+        lines.append(f"**Deferred:** {deferred_count} item(s) moved to the next milestone.")
+        lines.append("")
+
+    lines.append("### Release Checklist")
+    lines.append("")
+    lines.append("- [ ] Run `/release` ceremony (CHANGELOGs, version bumps, tag push)")
+    lines.append("- [ ] Verify all packages published successfully")
+    lines.append("- [ ] Close this milestone")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point.
+
+    Reads merged PRs from the JSON file, decides whether to open an issue,
+    and if so writes the issue body to stdout (default) or to ``--out``.
+    """
+    parser = argparse.ArgumentParser(
+        description="Decide whether to open a release issue after milestone closure.",
+    )
+    parser.add_argument(
+        "--milestone",
+        required=True,
+        help="Milestone title, e.g. 'v1.1.0'",
+    )
+    parser.add_argument(
+        "--description",
+        default="",
+        help="Milestone description text",
+    )
+    parser.add_argument(
+        "--merged-prs",
+        required=True,
+        dest="merged_prs",
+        help="Path to JSON file containing merged PRs: [{\"number\": N, \"title\": \"...\"}]",
+    )
+    parser.add_argument(
+        "--deferred-count",
+        type=int,
+        default=0,
+        dest="deferred_count",
+        help="Number of items deferred to the next milestone (default: 0)",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Write issue body to this file instead of stdout",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        prs_path = Path(args.merged_prs)
+        raw = prs_path.read_text(encoding="utf-8")
+        merged_prs: list[dict] = json.loads(raw) if raw.strip() else []
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: could not read merged PRs from {args.merged_prs!r}: {exc}", file=sys.stderr)
+        return 1
+
+    if not should_open_release_issue(merged_prs):
+        # Milestone closed with no merged PRs — nothing to release.
+        return 0
+
+    body = build_issue_body(
+        milestone_title=args.milestone,
+        milestone_description=args.description,
+        merged_prs=merged_prs,
+        deferred_count=args.deferred_count,
+    )
+
+    if args.out:
+        Path(args.out).write_text(body, encoding="utf-8")
+    else:
+        print(body, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_release_cadence.py
+++ b/scripts/ci/check_release_cadence.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Phase 4 — cadence floor workflow helper.
+
+Encapsulates the release cadence decision so that the GitHub Actions workflow
+``release-cadence-check.yml`` can call this script and parse its JSON output,
+and so that unit tests can exercise the decision logic without touching git,
+GitHub Actions, or the ``gh`` CLI.
+
+Public API
+----------
+evaluate_cadence(...)  — pure function, returns a decision dict
+build_issue_title(...)  — formats the check-in issue title
+build_issue_body(...)   — formats the check-in issue body (Markdown)
+main(argv=None)         — argparse entry point; prints JSON to stdout
+
+Usage (workflow)
+----------------
+    python scripts/ci/check_release_cadence.py \\
+        --last-release-date 2026-01-01 \\
+        --current-date      2026-04-24 \\
+        --unreleased-commits 12 \\
+        --last-release-tag   Cli-v1.0.0
+
+    # Optionally add --has-open-check-in-issue if an open issue already exists.
+
+Exit codes
+----------
+Always 0 — the caller reads the JSON ``should_open_issue`` field to decide
+whether to create an issue.  A non-zero exit would prevent ``$()`` capture
+in bash; we surface errors via stderr and still exit 0 so the workflow can
+fall through to the JSON parsing step gracefully.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Core decision logic
+# ---------------------------------------------------------------------------
+
+def evaluate_cadence(
+    *,
+    last_release_date: datetime,
+    current_date: datetime,
+    unreleased_commits: int,
+    has_open_check_in_issue: bool,
+    threshold_weeks: int = 8,
+) -> dict:
+    """Decide whether a cadence check-in issue should be opened.
+
+    Parameters
+    ----------
+    last_release_date:
+        The date/datetime of the most recent release tag.
+    current_date:
+        The date/datetime to treat as "now" (injectable for tests).
+    unreleased_commits:
+        Number of commits on main since the last release tag.
+    has_open_check_in_issue:
+        True if a GitHub issue with the ``release:cadence-check`` label is
+        already open — prevents duplicates.
+    threshold_weeks:
+        Minimum number of *complete* weeks that must have elapsed before the
+        check-in issue is opened (exclusive: > threshold, not >=).
+
+    Returns
+    -------
+    dict with keys:
+        should_open_issue   bool
+        reason              str  ("duplicate" | "recent release" |
+                                  "no unreleased commits" | "overdue")
+        weeks_since_release int  (floor of days / 7)
+        unreleased_commits  int  (echoed from input)
+    """
+    weeks_since_release = (current_date - last_release_date).days // 7
+
+    if has_open_check_in_issue:
+        return {
+            "should_open_issue": False,
+            "reason": "duplicate",
+            "weeks_since_release": weeks_since_release,
+            "unreleased_commits": unreleased_commits,
+        }
+
+    if weeks_since_release <= threshold_weeks:
+        return {
+            "should_open_issue": False,
+            "reason": "recent release",
+            "weeks_since_release": weeks_since_release,
+            "unreleased_commits": unreleased_commits,
+        }
+
+    if unreleased_commits == 0:
+        return {
+            "should_open_issue": False,
+            "reason": "no unreleased commits",
+            "weeks_since_release": weeks_since_release,
+            "unreleased_commits": unreleased_commits,
+        }
+
+    return {
+        "should_open_issue": True,
+        "reason": "overdue",
+        "weeks_since_release": weeks_since_release,
+        "unreleased_commits": unreleased_commits,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Issue formatting helpers
+# ---------------------------------------------------------------------------
+
+def build_issue_title(weeks: int, commits: int) -> str:
+    """Return the GitHub issue title for a cadence check-in issue."""
+    return (
+        f"Release check-in: {commits} commits unreleased, "
+        f"{weeks} weeks since last release"
+    )
+
+
+def build_issue_body(weeks: int, commits: int, last_release_tag: str) -> str:
+    """Return the GitHub issue body (Markdown) for a cadence check-in issue."""
+    return f"""\
+## Release Check-in
+
+The release cadence floor has been triggered: no release has shipped in the last **{weeks} weeks**, and there are **{commits} unreleased commits** on `main` since the last release tag.
+
+| Field | Value |
+|-------|-------|
+| Weeks since last release | {weeks} |
+| Unreleased commits on main | {commits} |
+| Last release tag | `{last_release_tag}` |
+
+## Options for the Maintainer
+
+- **Release now** — run `/release` to cut a patch or minor release
+- **Defer with reason** — comment on this issue explaining the deferral and close it; a new issue will open next week if the condition persists
+- **Close as not-needed** — if the unreleased commits are housekeeping/docs that don't warrant a release, close this issue with a note
+
+## Checklist
+
+- [ ] Review unreleased commits since `{last_release_tag}` — are any user-facing?
+- [ ] Decide: release now, defer, or close as not-needed
+- [ ] If releasing: run `/release` (see the skill for the full ceremony)
+- [ ] Close this issue once the decision is actioned
+"""
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate whether a release cadence check-in issue should be opened. "
+            "Outputs a JSON object to stdout; always exits 0."
+        ),
+    )
+    parser.add_argument(
+        "--last-release-date",
+        required=True,
+        help="ISO date string (YYYY-MM-DD) of the most recent release tag.",
+    )
+    parser.add_argument(
+        "--current-date",
+        default=None,
+        help=(
+            "ISO date string (YYYY-MM-DD) to treat as today. "
+            "Defaults to the actual current date."
+        ),
+    )
+    parser.add_argument(
+        "--unreleased-commits",
+        type=int,
+        required=True,
+        help="Number of commits on main since the last release tag.",
+    )
+    parser.add_argument(
+        "--has-open-check-in-issue",
+        action="store_true",
+        default=False,
+        help="Pass this flag if an open release:cadence-check issue already exists.",
+    )
+    parser.add_argument(
+        "--last-release-tag",
+        default="",
+        help="Tag name of the most recent release (used in issue body if opened).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "title", "body"],
+        default="json",
+        help=(
+            "Output format. 'json' (default) emits the evaluate_cadence result. "
+            "'title' emits the issue title string. 'body' emits the issue body markdown. "
+            "The 'title' and 'body' modes are used by the workflow to build gh issue create args."
+        ),
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        last_release_date = datetime.fromisoformat(args.last_release_date)
+    except ValueError as exc:
+        print(f"error: --last-release-date: {exc}", file=sys.stderr)
+        return 0  # still exit 0; JSON won't be valid but workflow reads stderr
+
+    if args.current_date is not None:
+        try:
+            current_date = datetime.fromisoformat(args.current_date)
+        except ValueError as exc:
+            print(f"error: --current-date: {exc}", file=sys.stderr)
+            return 0
+    else:
+        current_date = datetime.combine(date.today(), datetime.min.time())
+
+    result = evaluate_cadence(
+        last_release_date=last_release_date,
+        current_date=current_date,
+        unreleased_commits=args.unreleased_commits,
+        has_open_check_in_issue=args.has_open_check_in_issue,
+    )
+
+    if args.format == "title":
+        print(build_issue_title(
+            result["weeks_since_release"],
+            result["unreleased_commits"],
+        ))
+    elif args.format == "body":
+        print(build_issue_body(
+            result["weeks_since_release"],
+            result["unreleased_commits"],
+            args.last_release_tag,
+        ))
+    else:
+        print(json.dumps(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/map_files_to_packages.py
+++ b/scripts/ci/map_files_to_packages.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Map changed file paths to PPDS NuGet package names.
+
+Given a list of file paths (one per line on stdin, or via --files args),
+determines which PPDS packages are affected based on the ``src/PPDS.<Name>/``
+directory prefix.
+
+Usage:
+    python scripts/ci/map_files_to_packages.py --files src/PPDS.Query/Foo.cs
+    git diff --name-only HEAD~1 | python scripts/ci/map_files_to_packages.py
+
+Output:
+    JSON array of package names to stdout, e.g. ["PPDS.Cli", "PPDS.Query"]
+    Returns ["unknown"] when no paths match a recognized src/PPDS.* prefix.
+
+Exit codes:
+    0 — always (detection of unknown packages is surfaced in the output, not
+        via exit code — the caller reads the JSON and decides what to do)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Optional
+
+# The 8 NuGet packages that make up the PPDS platform.
+KNOWN_PACKAGES = frozenset({
+    "Auth",
+    "Cli",
+    "Dataverse",
+    "Extension",
+    "Mcp",
+    "Migration",
+    "Plugins",
+    "Query",
+})
+
+# Match src/PPDS.<Name>/ at the start of a path.  The name must be at least
+# one character and consist only of word characters (letters, digits,
+# underscores) — this rejects bare ``src/PPDS./foo.cs`` entries.
+_PREFIX_RE = re.compile(r"^src/PPDS\.(\w+)/")
+
+
+def map_files_to_packages(file_paths: list[str]) -> list[str]:
+    """Map a list of changed file paths to affected PPDS package names.
+
+    Parameters
+    ----------
+    file_paths:
+        Relative file paths as reported by ``git diff --name-only`` or
+        ``gh pr diff --name-only``.
+
+    Returns
+    -------
+    Sorted, deduplicated list of ``PPDS.<Name>`` package names whose source
+    directories appear in *file_paths*.  Returns ``["unknown"]`` if no path
+    matches a recognized ``src/PPDS.<Name>/`` prefix.
+    """
+    packages: set[str] = set()
+    for path in file_paths:
+        m = _PREFIX_RE.match(path)
+        if m:
+            name = m.group(1)
+            if name in KNOWN_PACKAGES:
+                packages.add(f"PPDS.{name}")
+    return sorted(packages) if packages else ["unknown"]
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Map changed file paths to PPDS package names.",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        metavar="PATH",
+        help="File paths to map (alternative to reading from stdin)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.files is not None:
+        file_paths = args.files
+    else:
+        file_paths = [line.rstrip("\n") for line in sys.stdin if line.strip()]
+
+    result = map_files_to_packages(file_paths)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/release-cycle.md
+++ b/specs/release-cycle.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Last Updated:** 2026-04-24
-**Code:** [.claude/skills/release/](../.claude/skills/release/), [.github/workflows/](../.github/workflows/)
+**Code:** [.claude/skills/release/](../.claude/skills/release/), [.github/workflows/](../.github/workflows/), [scripts/ci/](../scripts/ci/), [tests/ci/](../tests/ci/), [tests/test_release_skill_content.py](../tests/test_release_skill_content.py)
 **Surfaces:** All
 
 ---
@@ -210,8 +210,8 @@ A merged PR does NOT warrant `release:patch`:
 | AC-03 | `milestone-release-check.yml` opens a GitHub issue when a milestone reaches 100% closed with merged PRs | `tests/ci/test_milestone_release_check.py::test_opens_issue_on_milestone_complete` | 🔲 |
 | AC-04 | `release-cadence-check.yml` opens a check-in issue if >8 weeks since last release tag and >0 unreleased commits on main | `tests/ci/test_release_cadence_check.py::test_opens_issue_when_overdue` | 🔲 |
 | AC-05 | `release-cadence-check.yml` does NOT open an issue if a release was cut within the last 8 weeks | `tests/ci/test_release_cadence_check.py::test_no_issue_when_recent_release` | 🔲 |
-| AC-06 | `/release` skill contains a "Patch Release Procedure" section documenting the single-package abbreviated flow | `tests/test_release_skill_content.py::test_patch_procedure_documented` | 🔲 |
-| AC-07 | `/release` skill contains a "Stabilization Branch" section documenting when to create one and how to merge back | `tests/test_release_skill_content.py::test_stabilization_branch_documented` | 🔲 |
+| AC-06 | `/release` skill contains a "Patch Release Procedure" section documenting the single-package abbreviated flow | `tests/test_release_skill_content.py::test_patch_procedure_documented` | ✅ |
+| AC-07 | `/release` skill contains a "Stabilization Branch" section documenting when to create one and how to merge back | `tests/test_release_skill_content.py::test_stabilization_branch_documented` | ✅ |
 | AC-08 | `release-cadence-check.yml` does NOT open a duplicate issue if one is already open | `tests/ci/test_release_cadence_check.py::test_no_duplicate_issue` | 🔲 |
 | AC-09 | `milestone-release-check.yml` does NOT open a release issue when a milestone is closed with 0 merged PRs | `tests/ci/test_milestone_release_check.py::test_no_issue_on_empty_milestone` | 🔲 |
 | AC-10 | `post-merge-release-check.yml` opens an issue with "unknown package" warning when a `release:patch` PR touches no recognized `src/PPDS.*` paths | `tests/ci/test_post_merge_release_check.py::test_unknown_package_warning` | 🔲 |

--- a/specs/release-cycle.md
+++ b/specs/release-cycle.md
@@ -1,0 +1,305 @@
+# Release Cycle
+
+**Status:** Draft
+**Last Updated:** 2026-04-24
+**Code:** [.claude/skills/release/](../.claude/skills/release/), [.github/workflows/](../.github/workflows/)
+**Surfaces:** All
+
+---
+
+## Overview
+
+Policy layer governing *when* PPDS releases happen, *how* work is grouped into milestones, and *what* automation surfaces release readiness. The existing `/release` skill owns the ceremony (CHANGELOGs, version bumps, tag pushes, CI monitoring); this spec owns the decisions above it — triggering, targeting, branching, and enforcement.
+
+### Goals
+
+- **Predictable release cadence**: patches ship fast, minors ship when ready, nothing drifts silently
+- **Automated detection**: the system tells the maintainer when a release is warranted — not the other way around
+- **Manual ceremony**: irreversible actions (tag push, NuGet/Marketplace publish) remain human-initiated via `/release`
+
+### Non-Goals
+
+- Replacing the `/release` skill ceremony — this spec extends it, not replaces it
+- Auto-publishing to NuGet or Marketplace on merge — too risky for a multi-surface product
+- Release trains or calendar-driven minor releases — wrong for a solo maintainer
+- Cross-repo docs generation automation — covered by `specs/docs-generation.md`
+
+---
+
+## Architecture
+
+```
+PR merges to main
+       │
+       ├── label: release:patch ──▶ post-merge-release-check.yml
+       │                                  │
+       │                                  ▼
+       │                           Opens "Patch release needed"
+       │                           issue with package + diff
+       │
+       ├── milestone 100% closed ──▶ milestone-release-check.yml
+       │                                  │
+       │                                  ▼
+       │                           Opens "Milestone vX.Y.0 ready"
+       │                           issue with summary
+       │
+       └── (accumulates) ──────────▶ release-cadence-check.yml (weekly cron)
+                                          │
+                                          ▼
+                                   Opens "Release check-in" issue
+                                   if >8 weeks + unreleased commits
+
+All three paths lead to:
+       │
+       ▼
+  Maintainer runs /release (manual)
+       │
+       ▼
+  Tag push → CI publish workflows
+```
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `post-merge-release-check.yml` | Detects `release:patch` label on merged PRs, opens patch release issue |
+| `milestone-release-check.yml` | Detects milestone completion, opens minor release readiness issue |
+| `release-cadence-check.yml` | Weekly cron, checks days since last release tag, opens check-in issue |
+| `/release` skill (existing) | Release ceremony — CHANGELOGs, version bumps, tag push, CI monitoring |
+| GitHub Milestones | Group PRs into minor release targets (v1.1.0, v1.2.0, ...) |
+
+### Dependencies
+
+- Extends: [/release skill](../.claude/skills/release/SKILL.md) (ceremony)
+- Complements: [MERGE-POLICY.md](../docs/MERGE-POLICY.md) (how PRs merge)
+
+---
+
+## Specification
+
+### Release Types
+
+| Type | Version | Trigger | Scope | Example |
+|------|---------|---------|-------|---------|
+| Patch | `X.Y.Z` (Z > 0) | Bug fix or security fix merged with `release:patch` label | Per-package — only affected package(s) get new tags | `Query-v1.0.1` |
+| Minor | `X.Y.0` (Y > 0) | GitHub Milestone reaches 100% closed | All packages — coordinated release via `/release` | `Auth-v1.1.0`, `Cli-v1.1.0`, ... |
+| Major | `X.0.0` (X > 1) | Breaking change (API, strong-name rotation, etc.) | All packages — coordinated release via `/release` | Future |
+
+### Release Triggering Model
+
+Releases are **event-driven with a cadence floor**:
+
+1. **Patch releases** ship when ready. Any merged PR labeled `release:patch` triggers automated detection. The maintainer decides whether to release immediately or batch with other pending fixes.
+
+2. **Minor releases** ship when complete. GitHub Milestones define scope. When all issues/PRs in a milestone are closed, automated detection surfaces readiness. The maintainer runs `/release`.
+
+3. **Cadence floor**: if no release (patch or minor) has shipped in 8 weeks and main has unreleased commits, a scheduled workflow opens a check-in issue. This prevents drift where accumulated changes never ship because nothing feels "ready enough."
+
+### Milestone Targeting Strategy
+
+**GitHub Milestones** are the targeting mechanism:
+
+- Each planned minor release has a milestone: `v1.1.0`, `v1.2.0`, etc.
+- PRs are assigned to milestones when merged (or when the scope is known).
+- Patch releases do not need milestones — they are reactive and small.
+- A milestone can be deferred by moving its open issues to the next milestone and closing it.
+
+**Version progression:**
+
+- `1.0.0` → bug fix → `1.0.1` (patch, per-package)
+- `1.0.x` → feature batch → `1.1.0` (minor, all packages)
+- The Plugins package follows its own lineage (currently `3.0.0`) but its minor/patch increments follow the same policy.
+- Extension follows odd/even minor convention (odd = pre-release channel, even = stable).
+
+### Branching and Merge Policy
+
+**Trunk-based development with optional stabilization branches:**
+
+1. **Default path** (used for all patch releases and most minor releases):
+   - Feature/fix branches → squash-merge to main → tag from main → CI publishes
+   - No release branch needed. This is the current model and it works.
+
+2. **Stabilization branch** (rare, manual procedure — documented in `/release` skill per AC-07):
+   - Create `release/X.Y` from main at the point where the milestone is feature-complete
+   - Only cherry-pick bug fixes onto the stabilization branch
+   - Tag from the stabilization branch, not main
+   - Merge the branch back to main after release (or delete if all fixes were already on main)
+   - **When to use**: only if active development for X.(Y+1) has started on main before X.Y is verified and shipped. For a solo maintainer, this should be the exception.
+
+3. **Patch releases from main**:
+   - Bug fix merges to main as a normal PR
+   - Tag the affected package(s) from the merge commit on main
+   - No branch, no release PR needed for single-package patches
+   - Multi-package patches (rare) follow the standard `/release` ceremony
+
+### Patch Release Procedure
+
+For single-package patches (the common case):
+
+1. Fix merges to main via normal PR process
+2. Maintainer runs abbreviated `/release` targeting one package:
+   - Update that package's CHANGELOG only
+   - Push one tag (e.g., `Query-v1.0.1`)
+   - Monitor one `publish-nuget.yml` run
+   - Verify publish
+3. No release PR needed — the fix PR itself is the audit trail
+
+For multi-package patches or patches that touch the Extension:
+
+1. Follow the full `/release` ceremony (release PR, all CHANGELOGs, coordinated tags)
+
+### Severity-Based Patch Trigger
+
+Human policy — the `release:patch` label is applied by the maintainer at PR merge time based on judgment. The criteria below are guidelines, not automated enforcement.
+
+A merged PR warrants the `release:patch` label when any of these apply:
+
+- User-facing bug that causes wrong behavior, data loss, or crash
+- Security vulnerability (any severity)
+- Regression from a recent release
+
+A merged PR does NOT warrant `release:patch`:
+
+- Cosmetic or UX polish issues
+- Performance improvements (unless severe degradation)
+- Internal refactoring
+- Documentation-only changes
+- Test-only changes
+
+### Primary Flows
+
+**Flow 1 — Patch release (label-triggered):**
+
+1. **PR merges to main** with `release:patch` label
+2. **`post-merge-release-check.yml` fires**: identifies affected package(s) from changed file paths, opens a GitHub issue titled "Patch release needed: PPDS.{Package} vX.Y.Z"
+3. **Issue body includes**: affected package(s), commit summary, link to merged PR, checklist linking to `/release` steps
+4. **Maintainer reviews issue**, runs `/release` for the affected package(s)
+5. **Maintainer closes issue** after publish verification
+
+**Flow 2 — Minor release (milestone-driven):**
+
+1. **PRs merge to main** with milestone `vX.Y.0` assigned
+2. **Last issue/PR in milestone closes** → milestone reaches 100%
+3. **`milestone-release-check.yml` fires**: opens a GitHub issue titled "Milestone vX.Y.0 complete — ready for release"
+4. **Issue body includes**: milestone summary, PR list, any deferred items
+5. **Maintainer reviews**, runs full `/release` ceremony
+6. **Maintainer closes milestone and issue** after publish verification
+
+**Flow 3 — Cadence floor (scheduled):**
+
+1. **Weekly cron** (`release-cadence-check.yml`) runs on Monday
+2. **Checks**: last release tag date vs. today, commit count since last tag
+3. **If >8 weeks and >0 unreleased commits**: opens issue titled "Release check-in: {N} commits unreleased, {W} weeks since last release"
+4. **Maintainer triages**: release now, defer with reason, or close as not-needed
+
+### Constraints
+
+- Tag push is irreversible — never auto-tag or auto-publish
+- Per-package patching must not require re-releasing unaffected packages
+- Extension publish remains manual dispatch (documented workaround for GitHub Actions limitation)
+- All release types must produce CHANGELOG entries before tagging
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | `post-merge-release-check.yml` opens a GitHub issue when a PR with `release:patch` label merges to main | `tests/ci/test_post_merge_release_check.py::test_opens_issue_on_patch_label` | 🔲 |
+| AC-02 | The patch release issue body identifies affected package(s) by mapping changed file paths to package prefixes | `tests/ci/test_post_merge_release_check.py::test_maps_paths_to_packages` | 🔲 |
+| AC-03 | `milestone-release-check.yml` opens a GitHub issue when a milestone reaches 100% closed with merged PRs | `tests/ci/test_milestone_release_check.py::test_opens_issue_on_milestone_complete` | 🔲 |
+| AC-04 | `release-cadence-check.yml` opens a check-in issue if >8 weeks since last release tag and >0 unreleased commits on main | `tests/ci/test_release_cadence_check.py::test_opens_issue_when_overdue` | 🔲 |
+| AC-05 | `release-cadence-check.yml` does NOT open an issue if a release was cut within the last 8 weeks | `tests/ci/test_release_cadence_check.py::test_no_issue_when_recent_release` | 🔲 |
+| AC-06 | `/release` skill contains a "Patch Release Procedure" section documenting the single-package abbreviated flow | `tests/test_release_skill_content.py::test_patch_procedure_documented` | 🔲 |
+| AC-07 | `/release` skill contains a "Stabilization Branch" section documenting when to create one and how to merge back | `tests/test_release_skill_content.py::test_stabilization_branch_documented` | 🔲 |
+| AC-08 | `release-cadence-check.yml` does NOT open a duplicate issue if one is already open | `tests/ci/test_release_cadence_check.py::test_no_duplicate_issue` | 🔲 |
+| AC-09 | `milestone-release-check.yml` does NOT open a release issue when a milestone is closed with 0 merged PRs | `tests/ci/test_milestone_release_check.py::test_no_issue_on_empty_milestone` | 🔲 |
+| AC-10 | `post-merge-release-check.yml` opens an issue with "unknown package" warning when a `release:patch` PR touches no recognized `src/PPDS.*` paths | `tests/ci/test_post_merge_release_check.py::test_unknown_package_warning` | 🔲 |
+| AC-11 | `release-cadence-check.yml` does NOT open an issue if >8 weeks since last release but 0 unreleased commits on main | `tests/ci/test_release_cadence_check.py::test_no_issue_when_no_unreleased_commits` | 🔲 |
+| AC-12 | `post-merge-release-check.yml` identifies multiple affected packages when a `release:patch` PR touches paths in more than one package | `tests/ci/test_post_merge_release_check.py::test_multi_package_detection` | 🔲 |
+
+### Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| PR has `release:patch` but touches no `src/PPDS.*` paths | Issue opened with "unknown package" warning — maintainer triages manually |
+| Milestone closed with 0 PRs (deferred all) | No release issue opened — workflow checks PR count |
+| Two `release:patch` PRs merge in quick succession | Two separate issues opened — maintainer can batch into one patch release |
+| Cadence check runs but an open check-in issue already exists | No duplicate issue — workflow checks for existing open issues with the label |
+| Stabilization branch diverges from main | Maintainer merges back to main after release; conflicts resolved manually |
+
+---
+
+## Design Decisions
+
+### Why event-driven over calendar-driven?
+
+**Context:** Solo maintainer needs a release model that doesn't create artificial pressure but also doesn't let releases drift indefinitely.
+
+**Decision:** Event-driven (patches on severity, minors on milestone completion) with an 8-week cadence floor as a safety net.
+
+**Alternatives considered:**
+- **Calendar-driven (every N weeks)**: Creates pressure to ship half-baked features. Forces arbitrary scope cuts. Wrong for solo maintainer with variable bandwidth.
+- **Auto-release on merge**: Works for single-package libraries but dangerous for a multi-surface product where CLI + Extension + NuGet must be coherent. One bad merge auto-publishes to NuGet with no review.
+- **Pure ad-hoc ("ship when it feels right")**: Current model. Works but causes drift — the 5-7 week gaps between prereleases were accidental, not intentional.
+
+**Consequences:**
+- Positive: Patches ship fast, minors ship complete, cadence floor prevents drift
+- Negative: Requires discipline to label PRs and assign milestones (mitigated by automation surfacing gaps)
+
+### Why trunk-based over GitFlow?
+
+**Context:** Need a branching model that supports both patches and minors without coordination overhead.
+
+**Decision:** Trunk-based (main-only) with optional stabilization branches for rare cases.
+
+**Alternatives considered:**
+- **GitFlow (long-lived develop + release branches)**: Massive overhead for solo maintainer. Designed for teams of 5+ with parallel release tracks.
+- **Release branches per minor**: Creates merge-back burden. Solo maintainer ends up maintaining two branches for no benefit most of the time.
+- **Pure trunk (no stabilization escape hatch)**: Would work 90% of the time but leaves no option when 1.2 development starts before 1.1 is verified.
+
+**Consequences:**
+- Positive: Simple default path (just merge and tag), escape hatch exists if needed
+- Negative: Stabilization branches, when used, require cherry-pick discipline
+
+### Why automate detection but not ceremony?
+
+**Context:** Want to reduce cognitive load ("do I need to release?") without losing control over irreversible actions.
+
+**Decision:** Three detection workflows (patch label, milestone completion, cadence floor) that open issues. The `/release` skill ceremony remains human-initiated.
+
+**Alternatives considered:**
+- **Full auto-release**: Tag push on merge. Too risky — NuGet publishes are permanent (unlisting is possible but the version is consumed).
+- **Manual everything**: Current model. Works but relies on the maintainer remembering to check if a release is needed.
+
+**Consequences:**
+- Positive: Maintainer never misses a release trigger, never accidentally publishes
+- Negative: Three new workflows to maintain (mitigated by simplicity — each is ~50 lines)
+
+### Why per-package patching?
+
+**Context:** A bug in PPDS.Query shouldn't force re-releasing PPDS.Auth, PPDS.Plugins, and 5 other packages.
+
+**Decision:** Patch releases can target individual packages. Only the affected package gets a new tag and publish.
+
+**Alternatives considered:**
+- **Always release all packages together**: Simpler mental model but wastes CI time and creates noise on NuGet (7 packages with identical content, just bumped version).
+- **Per-package with dependency cascade**: If PPDS.Cli depends on PPDS.Query, bump both. Correct in theory but PPDS packages are independently versioned and consumers pin versions — a Query patch doesn't break Cli consumers.
+
+**Consequences:**
+- Positive: Fast, minimal patch releases. No noise on unaffected packages.
+- Negative: Requires the maintainer to know which package(s) a fix affects (mitigated by the detection workflow mapping file paths to packages).
+
+---
+
+## Related Specs
+
+- [docs-generation.md](./docs-generation.md) - Release tags trigger docs generation via `docs-release.yml`
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-04-24 | Initial spec |

--- a/specs/release-cycle.md
+++ b/specs/release-cycle.md
@@ -205,18 +205,18 @@ A merged PR does NOT warrant `release:patch`:
 
 | ID | Criterion | Test | Status |
 |----|-----------|------|--------|
-| AC-01 | `post-merge-release-check.yml` opens a GitHub issue when a PR with `release:patch` label merges to main | `tests/ci/test_post_merge_release_check.py::test_opens_issue_on_patch_label` | 🔲 |
-| AC-02 | The patch release issue body identifies affected package(s) by mapping changed file paths to package prefixes | `tests/ci/test_post_merge_release_check.py::test_maps_paths_to_packages` | 🔲 |
-| AC-03 | `milestone-release-check.yml` opens a GitHub issue when a milestone reaches 100% closed with merged PRs | `tests/ci/test_milestone_release_check.py::test_opens_issue_on_milestone_complete` | 🔲 |
-| AC-04 | `release-cadence-check.yml` opens a check-in issue if >8 weeks since last release tag and >0 unreleased commits on main | `tests/ci/test_release_cadence_check.py::test_opens_issue_when_overdue` | 🔲 |
-| AC-05 | `release-cadence-check.yml` does NOT open an issue if a release was cut within the last 8 weeks | `tests/ci/test_release_cadence_check.py::test_no_issue_when_recent_release` | 🔲 |
+| AC-01 | `post-merge-release-check.yml` opens a GitHub issue when a PR with `release:patch` label merges to main | `tests/ci/test_post_merge_release_check.py::test_opens_issue_on_patch_label` | ✅ |
+| AC-02 | The patch release issue body identifies affected package(s) by mapping changed file paths to package prefixes | `tests/ci/test_post_merge_release_check.py::test_maps_paths_to_packages` | ✅ |
+| AC-03 | `milestone-release-check.yml` opens a GitHub issue when a milestone reaches 100% closed with merged PRs | `tests/ci/test_milestone_release_check.py::test_opens_issue_on_milestone_complete` | ✅ |
+| AC-04 | `release-cadence-check.yml` opens a check-in issue if >8 weeks since last release tag and >0 unreleased commits on main | `tests/ci/test_release_cadence_check.py::test_opens_issue_when_overdue` | ✅ |
+| AC-05 | `release-cadence-check.yml` does NOT open an issue if a release was cut within the last 8 weeks | `tests/ci/test_release_cadence_check.py::test_no_issue_when_recent_release` | ✅ |
 | AC-06 | `/release` skill contains a "Patch Release Procedure" section documenting the single-package abbreviated flow | `tests/test_release_skill_content.py::test_patch_procedure_documented` | ✅ |
 | AC-07 | `/release` skill contains a "Stabilization Branch" section documenting when to create one and how to merge back | `tests/test_release_skill_content.py::test_stabilization_branch_documented` | ✅ |
-| AC-08 | `release-cadence-check.yml` does NOT open a duplicate issue if one is already open | `tests/ci/test_release_cadence_check.py::test_no_duplicate_issue` | 🔲 |
-| AC-09 | `milestone-release-check.yml` does NOT open a release issue when a milestone is closed with 0 merged PRs | `tests/ci/test_milestone_release_check.py::test_no_issue_on_empty_milestone` | 🔲 |
-| AC-10 | `post-merge-release-check.yml` opens an issue with "unknown package" warning when a `release:patch` PR touches no recognized `src/PPDS.*` paths | `tests/ci/test_post_merge_release_check.py::test_unknown_package_warning` | 🔲 |
-| AC-11 | `release-cadence-check.yml` does NOT open an issue if >8 weeks since last release but 0 unreleased commits on main | `tests/ci/test_release_cadence_check.py::test_no_issue_when_no_unreleased_commits` | 🔲 |
-| AC-12 | `post-merge-release-check.yml` identifies multiple affected packages when a `release:patch` PR touches paths in more than one package | `tests/ci/test_post_merge_release_check.py::test_multi_package_detection` | 🔲 |
+| AC-08 | `release-cadence-check.yml` does NOT open a duplicate issue if one is already open | `tests/ci/test_release_cadence_check.py::test_no_duplicate_issue` | ✅ |
+| AC-09 | `milestone-release-check.yml` does NOT open a release issue when a milestone is closed with 0 merged PRs | `tests/ci/test_milestone_release_check.py::test_no_issue_on_empty_milestone` | ✅ |
+| AC-10 | `post-merge-release-check.yml` opens an issue with "unknown package" warning when a `release:patch` PR touches no recognized `src/PPDS.*` paths | `tests/ci/test_post_merge_release_check.py::test_unknown_package_warning` | ✅ |
+| AC-11 | `release-cadence-check.yml` does NOT open an issue if >8 weeks since last release but 0 unreleased commits on main | `tests/ci/test_release_cadence_check.py::test_no_issue_when_no_unreleased_commits` | ✅ |
+| AC-12 | `post-merge-release-check.yml` identifies multiple affected packages when a `release:patch` PR touches paths in more than one package | `tests/ci/test_post_merge_release_check.py::test_multi_package_detection` | ✅ |
 
 ### Edge Cases
 

--- a/tests/ci/test_milestone_release_check.py
+++ b/tests/ci/test_milestone_release_check.py
@@ -1,0 +1,156 @@
+"""Unit tests for scripts/ci/check_milestone_completion.py.
+
+Run with: python -m pytest tests/ci/test_milestone_release_check.py -v
+
+Covers AC-03 and AC-09 from specs/release-cycle.md.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+import check_milestone_completion as cmc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# AC-03: opens issue when milestone has merged PRs
+# ---------------------------------------------------------------------------
+
+class TestOpensIssueOnMilestoneComplete:
+    """AC-03: milestone-release-check.yml opens a GitHub issue when a milestone
+    reaches 100% closed with merged PRs."""
+
+    def test_opens_issue_on_milestone_complete(self):
+        """should_open_release_issue returns True for a non-empty PR list."""
+        prs = [
+            {"number": 1, "title": "x"},
+            {"number": 2, "title": "y"},
+            {"number": 3, "title": "z"},
+        ]
+        assert cmc.should_open_release_issue(prs) is True
+
+    def test_build_issue_body_contains_milestone_title(self):
+        """build_issue_body includes the milestone title in the returned body."""
+        body = cmc.build_issue_body(
+            "v1.1.0",
+            "First minor",
+            [{"number": 1, "title": "feat A"}, {"number": 2, "title": "fix B"}],
+        )
+        assert "v1.1.0" in body
+
+    def test_build_issue_body_contains_pr_titles(self):
+        """build_issue_body includes PR titles in the returned body."""
+        body = cmc.build_issue_body(
+            "v1.1.0",
+            "First minor",
+            [{"number": 1, "title": "feat A"}, {"number": 2, "title": "fix B"}],
+        )
+        assert "feat A" in body
+        assert "fix B" in body
+
+    def test_build_issue_body_contains_pr_numbers(self):
+        """build_issue_body includes PR numbers (as #N) in the returned body."""
+        body = cmc.build_issue_body(
+            "v1.1.0",
+            "First minor",
+            [{"number": 1, "title": "feat A"}, {"number": 2, "title": "fix B"}],
+        )
+        assert "#1" in body
+        assert "#2" in body
+
+
+# ---------------------------------------------------------------------------
+# AC-09: does NOT open issue on empty milestone
+# ---------------------------------------------------------------------------
+
+class TestNoIssueOnEmptyMilestone:
+    """AC-09: milestone-release-check.yml does NOT open a release issue when a
+    milestone is closed with 0 merged PRs."""
+
+    def test_no_issue_on_empty_milestone(self):
+        """should_open_release_issue returns False for an empty PR list."""
+        assert cmc.should_open_release_issue([]) is False
+
+    def test_main_empty_prs_produces_no_output_and_exits_0(self, tmp_path, capsys):
+        """main() with an empty merged-prs file prints nothing and returns 0."""
+        prs_file = tmp_path / "merged_prs.json"
+        prs_file.write_text("[]", encoding="utf-8")
+
+        rc = cmc.main([
+            "--milestone", "v1.1.0",
+            "--merged-prs", str(prs_file),
+        ])
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Additional behavioral tests
+# ---------------------------------------------------------------------------
+
+class TestBuildIssueBodyDeferred:
+    def test_body_includes_deferred_count_when_nonzero(self):
+        """build_issue_body includes the deferred count when deferred_count > 0."""
+        body = cmc.build_issue_body(
+            "v1.2.0",
+            "",
+            [{"number": 5, "title": "feat C"}],
+            deferred_count=2,
+        )
+        assert "2" in body
+
+    def test_body_omits_deferred_when_zero(self):
+        """build_issue_body does not mention deferred items when count is 0."""
+        body = cmc.build_issue_body(
+            "v1.2.0",
+            "",
+            [{"number": 5, "title": "feat C"}],
+            deferred_count=0,
+        )
+        # Should not contain misleading "Deferred: 2" or similar text
+        assert "Deferred:" not in body
+
+
+class TestBuildIssueBodyChecklist:
+    def test_body_includes_release_checklist(self):
+        """build_issue_body includes a checklist item referencing /release."""
+        body = cmc.build_issue_body(
+            "v1.1.0",
+            "",
+            [{"number": 1, "title": "some PR"}],
+        )
+        assert "/release" in body
+
+
+class TestMainWritesToStdout:
+    def test_main_writes_body_to_stdout_when_prs_present(self, tmp_path, capsys):
+        """main() with non-empty merged-prs writes the issue body to stdout."""
+        prs_file = tmp_path / "merged_prs.json"
+        prs_file.write_text(
+            json.dumps([
+                {"number": 10, "title": "Add feature X"},
+                {"number": 11, "title": "Fix bug Y"},
+            ]),
+            encoding="utf-8",
+        )
+
+        rc = cmc.main([
+            "--milestone", "v2.0.0",
+            "--description", "Big release",
+            "--merged-prs", str(prs_file),
+        ])
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "v2.0.0" in captured.out
+        assert "#10" in captured.out
+        assert "Add feature X" in captured.out
+        assert "/release" in captured.out

--- a/tests/ci/test_post_merge_release_check.py
+++ b/tests/ci/test_post_merge_release_check.py
@@ -1,0 +1,257 @@
+"""Behavioral tests for the patch release detection workflow.
+
+Covers:
+  AC-01  Workflow opens issue on release:patch label merge
+  AC-02  Mapping changed file paths to package names
+  AC-10  Unknown-package warning when no src/PPDS.* paths found
+  AC-12  Multi-package detection
+
+Run with: python -m pytest tests/ci/test_post_merge_release_check.py -v
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+import map_files_to_packages as mfp  # noqa: E402
+
+# Path to the workflow file under test.
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "post-merge-release-check.yml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_workflow() -> dict:
+    """Load the workflow YAML, using PyYAML if available."""
+    try:
+        import yaml  # type: ignore
+        with WORKFLOW_PATH.open(encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except ImportError:
+        pytest.skip("PyYAML not installed; cannot parse workflow YAML")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC-01  Workflow structure: opens issue on release:patch label + merged state
+# ---------------------------------------------------------------------------
+
+class TestOpensIssueOnPatchLabel:
+    """AC-01 — workflow opens issue when merged PR has release:patch label."""
+
+    def test_opens_issue_on_patch_label(self):
+        """Parse the YAML and assert the job conditional and issue creation step
+        are both present and reference the expected conditions."""
+        wf = _load_workflow()
+
+        # Find the job
+        jobs = wf.get("jobs", {})
+        assert jobs, "Workflow has no jobs"
+
+        job = next(iter(jobs.values()))
+
+        # The job-level `if` must check both merged state and the label.
+        job_if = str(job.get("if", ""))
+        assert "merged" in job_if, (
+            f"Job `if` condition does not reference merged state: {job_if!r}"
+        )
+        assert "release:patch" in job_if, (
+            f"Job `if` condition does not reference 'release:patch' label: {job_if!r}"
+        )
+
+        # At least one step must use `gh issue create`.
+        steps = job.get("steps", [])
+        issue_create_steps = [
+            s for s in steps
+            if "run" in s and "gh issue create" in str(s.get("run", ""))
+        ]
+        assert issue_create_steps, (
+            "No step found that calls 'gh issue create'"
+        )
+
+    def test_workflow_trigger_is_pr_closed_on_main(self):
+        """Workflow must fire on pull_request closed events targeting main."""
+        wf = _load_workflow()
+        on = wf.get("on") or wf.get(True)  # YAML parses `on` as True in some loaders
+        pr_trigger = on.get("pull_request", {}) if isinstance(on, dict) else {}
+        assert "closed" in (pr_trigger.get("types") or []), (
+            "Workflow trigger must include pull_request type: closed"
+        )
+        assert "main" in (pr_trigger.get("branches") or []), (
+            "Workflow trigger must target branch: main"
+        )
+
+    def test_issue_created_with_patch_label(self):
+        """gh issue create command must include --label release:patch."""
+        text = _workflow_text()
+        assert "--label" in text and "release:patch" in text, (
+            "gh issue create must use --label release:patch"
+        )
+
+    def test_workflow_uses_github_token(self):
+        """Workflow must use GITHUB_TOKEN for gh CLI auth."""
+        text = _workflow_text()
+        assert "GITHUB_TOKEN" in text, (
+            "Workflow must reference secrets.GITHUB_TOKEN"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-02  map_files_to_packages — basic path mapping
+# ---------------------------------------------------------------------------
+
+class TestMapsPathsToPackages:
+    """AC-02 — issue body maps changed paths to package names."""
+
+    def test_maps_paths_to_packages(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Query/Foo.cs"])
+        assert result == ["PPDS.Query"]
+
+    def test_maps_auth_package(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Auth/AuthService.cs"])
+        assert result == ["PPDS.Auth"]
+
+    def test_maps_cli_package(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Cli/Program.cs"])
+        assert result == ["PPDS.Cli"]
+
+    def test_maps_dataverse_package(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Dataverse/Client.cs"])
+        assert result == ["PPDS.Dataverse"]
+
+    def test_maps_extension_package(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Extension/Extension.cs"])
+        assert result == ["PPDS.Extension"]
+
+    def test_maps_mcp_package(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Mcp/Server.cs"])
+        assert result == ["PPDS.Mcp"]
+
+    def test_maps_migration_package(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Migration/Runner.cs"])
+        assert result == ["PPDS.Migration"]
+
+    def test_maps_plugins_package(self):
+        result = mfp.map_files_to_packages(["src/PPDS.Plugins/Plugin.cs"])
+        assert result == ["PPDS.Plugins"]
+
+    def test_result_is_sorted(self):
+        result = mfp.map_files_to_packages([
+            "src/PPDS.Query/A.cs",
+            "src/PPDS.Auth/B.cs",
+        ])
+        assert result == sorted(result), "Result must be sorted alphabetically"
+
+    def test_result_is_deduplicated(self):
+        """Same package appearing twice returns only one entry."""
+        result = mfp.map_files_to_packages([
+            "src/PPDS.Query/Foo.cs",
+            "src/PPDS.Query/Bar.cs",
+        ])
+        assert result == ["PPDS.Query"]
+
+
+# ---------------------------------------------------------------------------
+# AC-10  Unknown-package warning
+# ---------------------------------------------------------------------------
+
+class TestUnknownPackageWarning:
+    """AC-10 — unknown warning when no src/PPDS.* paths found."""
+
+    def test_unknown_package_warning(self):
+        """Non-PPDS paths return ["unknown"] from the mapping script."""
+        result = mfp.map_files_to_packages(["docs/README.md"])
+        assert result == ["unknown"]
+
+    def test_workflow_contains_unknown_warning_string(self):
+        """Workflow YAML must contain the warning text for the unknown case."""
+        text = _workflow_text()
+        assert "No recognized PPDS package paths found" in text, (
+            "Workflow must include the 'No recognized PPDS package paths found' warning text"
+        )
+
+    def test_empty_input_returns_unknown(self):
+        """Empty input list returns ["unknown"]."""
+        result = mfp.map_files_to_packages([])
+        assert result == ["unknown"]
+
+    def test_empty_string_path_returns_unknown(self):
+        result = mfp.map_files_to_packages([""])
+        assert result == ["unknown"]
+
+    def test_bare_ppds_prefix_no_name_returns_unknown(self):
+        """Path like src/PPDS./foo.cs has no name segment — must return unknown."""
+        result = mfp.map_files_to_packages(["src/PPDS./foo.cs"])
+        assert result == ["unknown"]
+
+    def test_unrecognized_ppds_subdir_returns_unknown(self):
+        """src/PPDS.UnknownLib/X.cs is not one of the 8 known packages."""
+        result = mfp.map_files_to_packages(["src/PPDS.UnknownLib/X.cs"])
+        assert result == ["unknown"]
+
+    def test_test_paths_do_not_map_to_packages(self):
+        result = mfp.map_files_to_packages(["tests/PPDS.Query.Tests/FooTests.cs"])
+        assert result == ["unknown"]
+
+    def test_docs_path_returns_unknown(self):
+        result = mfp.map_files_to_packages(["docs/release-cycle.md"])
+        assert result == ["unknown"]
+
+
+# ---------------------------------------------------------------------------
+# AC-12  Multi-package detection
+# ---------------------------------------------------------------------------
+
+class TestMultiPackageDetection:
+    """AC-12 — multiple packages detected when PR touches multiple src/PPDS.* dirs."""
+
+    def test_multi_package_detection(self):
+        result = mfp.map_files_to_packages([
+            "src/PPDS.Query/Foo.cs",
+            "src/PPDS.Cli/Bar.cs",
+        ])
+        assert result == ["PPDS.Cli", "PPDS.Query"]
+
+    def test_three_packages(self):
+        result = mfp.map_files_to_packages([
+            "src/PPDS.Auth/X.cs",
+            "src/PPDS.Mcp/Y.cs",
+            "src/PPDS.Plugins/Z.cs",
+        ])
+        assert result == ["PPDS.Auth", "PPDS.Mcp", "PPDS.Plugins"]
+
+    def test_mixed_known_and_unknown_paths(self):
+        """Only recognized paths contribute to the result."""
+        result = mfp.map_files_to_packages([
+            "src/PPDS.Query/Foo.cs",
+            "docs/README.md",
+            ".github/workflows/ci.yml",
+        ])
+        assert result == ["PPDS.Query"]
+
+    def test_all_eight_packages(self):
+        paths = [
+            "src/PPDS.Auth/A.cs",
+            "src/PPDS.Cli/B.cs",
+            "src/PPDS.Dataverse/C.cs",
+            "src/PPDS.Extension/D.cs",
+            "src/PPDS.Mcp/E.cs",
+            "src/PPDS.Migration/F.cs",
+            "src/PPDS.Plugins/G.cs",
+            "src/PPDS.Query/H.cs",
+        ]
+        result = mfp.map_files_to_packages(paths)
+        assert result == sorted([
+            "PPDS.Auth", "PPDS.Cli", "PPDS.Dataverse", "PPDS.Extension",
+            "PPDS.Mcp", "PPDS.Migration", "PPDS.Plugins", "PPDS.Query",
+        ])

--- a/tests/ci/test_release_cadence_check.py
+++ b/tests/ci/test_release_cadence_check.py
@@ -1,0 +1,276 @@
+"""Unit tests for scripts/ci/check_release_cadence.py.
+
+Run with: python -m pytest tests/ci/test_release_cadence_check.py -v
+
+Each test exercises the public functions of check_release_cadence directly —
+no source-code inspection, no string matching on implementation text.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+import check_release_cadence as crc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# AC-04 — opens issue when overdue
+# ---------------------------------------------------------------------------
+
+class TestOpensIssueWhenOverdue:
+    """AC-04: issue is opened when >8 weeks have passed and commits exist."""
+
+    def test_opens_issue_when_overdue(self):
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=9)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=15,
+            has_open_check_in_issue=False,
+        )
+
+        assert result["should_open_issue"] is True
+        assert result["weeks_since_release"] == 9
+        assert result["unreleased_commits"] == 15
+
+    def test_opens_issue_when_overdue_negative_case(self):
+        """Negative: same dates but 0 commits — result must flip to False."""
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=9)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=0,
+            has_open_check_in_issue=False,
+        )
+
+        assert result["should_open_issue"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC-05 — no issue when release is recent
+# ---------------------------------------------------------------------------
+
+class TestNoIssueWhenRecentRelease:
+    """AC-05: issue is NOT opened when a release was cut within the last 8 weeks."""
+
+    def test_no_issue_when_recent_release(self):
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=3)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=10,
+            has_open_check_in_issue=False,
+        )
+
+        assert result["should_open_issue"] is False
+        # reason must mention "recent"
+        assert "recent" in result["reason"]
+
+    def test_no_issue_when_recent_release_negative_case(self):
+        """Negative: push past the threshold — result must flip to True."""
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=9)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=10,
+            has_open_check_in_issue=False,
+        )
+
+        assert result["should_open_issue"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC-08 — no duplicate issue
+# ---------------------------------------------------------------------------
+
+class TestNoDuplicateIssue:
+    """AC-08: issue is NOT opened when one is already open."""
+
+    def test_no_duplicate_issue(self):
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=9)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=15,
+            has_open_check_in_issue=True,
+        )
+
+        assert result["should_open_issue"] is False
+        assert "duplicate" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — no issue when 0 unreleased commits
+# ---------------------------------------------------------------------------
+
+class TestNoIssueWhenNoUnreleasedCommits:
+    """AC-11: issue is NOT opened when >8 weeks but 0 unreleased commits."""
+
+    def test_no_issue_when_no_unreleased_commits(self):
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=9)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=0,
+            has_open_check_in_issue=False,
+        )
+
+        assert result["should_open_issue"] is False
+        assert "no unreleased commits" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Boundary / threshold tests
+# ---------------------------------------------------------------------------
+
+class TestThresholdBoundary:
+    def test_threshold_boundary_exactly_8_weeks(self):
+        """Spec says '>8 weeks', so at exactly 8 weeks the issue must NOT open."""
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=8)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=5,
+            has_open_check_in_issue=False,
+        )
+
+        assert result["should_open_issue"] is False
+        assert result["weeks_since_release"] == 8
+
+    def test_threshold_boundary_one_day_past_8_weeks(self):
+        """One day past 8 full weeks still counts as 8 weeks (floor division)."""
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=8, days=1)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=5,
+            has_open_check_in_issue=False,
+        )
+
+        # 57 days // 7 == 8 — still at the boundary, NOT >8 weeks
+        assert result["should_open_issue"] is False
+
+    def test_threshold_boundary_9_weeks(self):
+        """At 9 complete weeks the issue MUST open (commits > 0, no duplicate)."""
+        now = datetime(2026, 4, 24)
+        last = now - timedelta(weeks=9)
+
+        result = crc.evaluate_cadence(
+            last_release_date=last,
+            current_date=now,
+            unreleased_commits=1,
+            has_open_check_in_issue=False,
+        )
+
+        assert result["should_open_issue"] is True
+        assert result["weeks_since_release"] == 9
+
+
+# ---------------------------------------------------------------------------
+# Issue formatting
+# ---------------------------------------------------------------------------
+
+class TestBuildIssueTitle:
+    def test_build_issue_title_format(self):
+        title = crc.build_issue_title(9, 15)
+        assert "9 weeks" in title
+        assert "15 commits" in title
+
+    def test_build_issue_title_singular_values(self):
+        title = crc.build_issue_title(1, 1)
+        assert "1 weeks" in title or "1 week" in title
+        assert "1 commits" in title or "1 commit" in title
+
+
+class TestBuildIssueBody:
+    def test_build_issue_body_includes_release_checklist(self):
+        body = crc.build_issue_body(9, 15, "Cli-v1.0.0")
+        assert "/release" in body
+        assert "Cli-v1.0.0" in body
+
+    def test_build_issue_body_includes_week_and_commit_counts(self):
+        body = crc.build_issue_body(9, 15, "Cli-v1.0.0")
+        assert "9" in body
+        assert "15" in body
+
+    def test_build_issue_body_includes_maintainer_options(self):
+        body = crc.build_issue_body(9, 15, "Cli-v1.0.0")
+        # Should mention the three options described in the spec
+        assert "defer" in body.lower() or "Defer" in body
+        assert "close" in body.lower() or "Close" in body
+
+
+# ---------------------------------------------------------------------------
+# main() entry point
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    def test_main_outputs_valid_json(self, capsys):
+        rc = crc.main([
+            "--last-release-date", "2026-02-01",
+            "--current-date", "2026-04-24",
+            "--unreleased-commits", "5",
+        ])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        assert set(data.keys()) == {
+            "should_open_issue",
+            "reason",
+            "weeks_since_release",
+            "unreleased_commits",
+        }
+        assert rc == 0
+
+    def test_main_overdue_scenario(self, capsys):
+        crc.main([
+            "--last-release-date", "2026-01-01",
+            "--current-date", "2026-04-24",
+            "--unreleased-commits", "12",
+        ])
+        data = json.loads(capsys.readouterr().out)
+        assert data["should_open_issue"] is True
+        assert data["weeks_since_release"] >= 16
+
+    def test_main_duplicate_flag(self, capsys):
+        crc.main([
+            "--last-release-date", "2025-12-01",
+            "--current-date", "2026-04-24",
+            "--unreleased-commits", "20",
+            "--has-open-check-in-issue",
+        ])
+        data = json.loads(capsys.readouterr().out)
+        assert data["should_open_issue"] is False
+        assert data["reason"] == "duplicate"
+
+    def test_main_recent_release_scenario(self, capsys):
+        crc.main([
+            "--last-release-date", "2026-04-10",
+            "--current-date", "2026-04-24",
+            "--unreleased-commits", "3",
+        ])
+        data = json.loads(capsys.readouterr().out)
+        assert data["should_open_issue"] is False
+        assert "recent" in data["reason"]

--- a/tests/test_release_skill_content.py
+++ b/tests/test_release_skill_content.py
@@ -1,0 +1,93 @@
+"""Tests for /release skill content (AC-06, AC-07).
+
+These verify that the /release skill SKILL.md file documents the
+single-package patch flow and the stabilization branch escape hatch.
+The SKILL.md file IS the canonical runbook — when it changes, these
+tests catch regressions in the documented process.
+
+Run with: python -m pytest tests/test_release_skill_content.py -v
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / ".claude" / "skills" / "release" / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Read SKILL.md once per module."""
+    if not SKILL_PATH.exists():
+        pytest.fail(f"/release skill not found at {SKILL_PATH}")
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def test_patch_procedure_documented(skill_text: str) -> None:
+    """AC-06: SKILL.md contains a 'Patch Release Procedure' section
+    documenting the abbreviated single-package flow.
+    """
+    # Heading present
+    assert "## Patch Release Procedure" in skill_text, (
+        "Expected '## Patch Release Procedure' heading in /release SKILL.md"
+    )
+    # Key terms in the section content (case-insensitive)
+    lowered = skill_text.lower()
+    assert "single-package" in lowered or "single package" in lowered, (
+        "Patch Release Procedure should mention single-package scope"
+    )
+    assert "abbreviated" in lowered, (
+        "Patch Release Procedure should describe the flow as abbreviated"
+    )
+    assert "changelog" in lowered, (
+        "Patch Release Procedure should reference CHANGELOG updates"
+    )
+
+
+def test_stabilization_branch_documented(skill_text: str) -> None:
+    """AC-07: SKILL.md contains a 'Stabilization Branch' section
+    documenting when to create one and how to merge back.
+    """
+    # Heading present
+    assert "## Stabilization Branch" in skill_text, (
+        "Expected '## Stabilization Branch' heading in /release SKILL.md"
+    )
+    lowered = skill_text.lower()
+    # Branch naming convention
+    assert "release/x.y" in lowered, (
+        "Stabilization Branch section should document release/X.Y naming"
+    )
+    # Cherry-pick discipline
+    assert "cherry-pick" in lowered, (
+        "Stabilization Branch section should describe cherry-pick discipline"
+    )
+    # Merge-back path
+    assert "merge back" in lowered or "merge-back" in lowered or "merge back to main" in lowered, (
+        "Stabilization Branch section should describe merging back to main"
+    )
+
+
+def test_patch_procedure_appears_before_known_gotchas(skill_text: str) -> None:
+    """The new sections should be inside the Process documentation, before
+    the troubleshooting/recovery sections. Catches accidental placement at
+    the very end of the file."""
+    patch_idx = skill_text.find("## Patch Release Procedure")
+    gotchas_idx = skill_text.find("## Known Gotchas")
+    assert patch_idx > 0, "Patch Release Procedure section missing"
+    assert gotchas_idx > 0, "Known Gotchas section missing"
+    assert patch_idx < gotchas_idx, (
+        "Patch Release Procedure should appear before Known Gotchas"
+    )
+
+
+def test_stabilization_branch_appears_before_known_gotchas(skill_text: str) -> None:
+    """Symmetric check for the Stabilization Branch section placement."""
+    stab_idx = skill_text.find("## Stabilization Branch")
+    gotchas_idx = skill_text.find("## Known Gotchas")
+    assert stab_idx > 0, "Stabilization Branch section missing"
+    assert gotchas_idx > 0, "Known Gotchas section missing"
+    assert stab_idx < gotchas_idx, (
+        "Stabilization Branch should appear before Known Gotchas"
+    )


### PR DESCRIPTION
## Summary

- **Spec** (`specs/release-cycle.md`): defines the policy layer above the existing `/release` skill — when releases happen, how work is grouped into milestones, what branching model to use, and what automation surfaces release readiness
- **Three detection workflows**: `post-merge-release-check.yml` (patch label → issue), `milestone-release-check.yml` (milestone completion → issue), `release-cadence-check.yml` (8-week floor → issue)
- **`/release` skill extensions**: patch release procedure and stabilization branch sections added to the existing skill
- **58 tests** covering all 12 spec ACs across 4 test files
- **4 deferred issues** created (#912–#915) assigned to v1.1 milestone

### Key decisions

- **Event-driven triggering** with 8-week cadence floor (not calendar-driven, not auto-on-merge)
- **GitHub Milestones** for minor release targeting; patch releases are reactive and per-package
- **Trunk-based branching** with optional stabilization branches (rare exception, not default)
- **Automate detection, keep ceremony manual** — workflows open issues, `/release` stays human-initiated

## Test plan

- [x] `pytest tests/test_release_skill_content.py -v` — 4/4 passing
- [x] `pytest tests/ci/test_post_merge_release_check.py -v` — 26/26 passing
- [x] `pytest tests/ci/test_milestone_release_check.py -v` — 10/10 passing
- [x] `pytest tests/ci/test_release_cadence_check.py -v` — 18/18 passing
- [x] `.NET build` — 0 errors
- [x] `.NET unit tests` — 3301/3302 passing (1 pre-existing failure: #879)
- [x] `Extension tests` — 433/433 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)