### PR TITLE
fix(extension): point plugin registration help to main docs page (#900)

### DIFF
--- a/.claude/state/in-flight-issues.json
+++ b/.claude/state/in-flight-issues.json
@@ -1,57 +1,61 @@
 {
   "version": 1,
-  "updated": "2026-04-24T17:12:22Z",
+  "updated": "2026-04-25T02:24:51Z",
   "open_work": [
     {
-      "session_id": "e8079a50",
-      "started": "2026-04-24T17:12:20Z",
-      "branch": "feat/profiles-spinner-fix",
-      "worktree": ".worktrees/profiles-spinner-fix",
+      "session_id": "7ce1ca2d",
+      "started": "2026-04-25T02:24:51Z",
+      "branch": "feat/profile-env-ux",
+      "worktree": ".worktrees/profile-env-ux",
       "issues": [
-        904
+        887,
+        888,
+        903
       ],
       "areas": [
         "extension"
       ],
-      "intent": "Fix profiles tree infinite spinner - add RPC timeouts and error states"
+      "intent": "Profile/environment UX redesign: status bar grouping, panel vs status bar, cmd palette filtering"
     },
     {
-      "session_id": "4500f1bb",
-      "started": "2026-04-24T17:12:21Z",
-      "branch": "feat/tds-assembly-fix",
-      "worktree": ".worktrees/tds-assembly-fix",
+      "session_id": "14ad7d38",
+      "started": "2026-04-25T02:24:51Z",
+      "branch": "feat/plugin-reg-styling",
+      "worktree": ".worktrees/plugin-reg-styling",
       "issues": [
-        889
-      ],
-      "areas": [
-        "cli"
-      ],
-      "intent": "Fix TDS Endpoint Microsoft.Data.SqlClient assembly not found"
-    },
-    {
-      "session_id": "7d08a8f8",
-      "started": "2026-04-24T17:12:22Z",
-      "branch": "feat/sync-settings-fix",
-      "worktree": ".worktrees/sync-settings-fix",
-      "issues": [
-        893
+        896,
+        897
       ],
       "areas": [
         "extension"
       ],
-      "intent": "Fix Sync Deployment Settings getting stuck"
-  "updated": "2026-04-24T18:26:11Z",
-  "open_work": [
+      "intent": "Plugin Registration styling: unstyled buttons and collapse arrow sizing"
+    },
     {
-      "session_id": "dd8f64eb",
-      "started": "2026-04-24T18:26:11Z",
-      "branch": "feat/release-cycle-design",
-      "worktree": ".worktrees/release-cycle-design",
-      "issues": [],
-      "areas": [
-        "release"
+      "session_id": "c54fdb3d",
+      "started": "2026-04-25T02:24:51Z",
+      "branch": "feat/metadata-browser-config",
+      "worktree": ".worktrees/metadata-browser-config",
+      "issues": [
+        901
       ],
-      "intent": "Design release cycle workflow: triggering, milestone targeting, branching policy, enforcement gaps"
+      "areas": [
+        "extension"
+      ],
+      "intent": "Metadata Browser: add entity configuration tab and global optionset details"
+    },
+    {
+      "session_id": "eb69b7d9",
+      "started": "2026-04-25T02:24:51Z",
+      "branch": "feat/docs-plugin-reg",
+      "worktree": ".worktrees/docs-plugin-reg",
+      "issues": [
+        900
+      ],
+      "areas": [
+        "extension"
+      ],
+      "intent": "Fix docs plugin-registration 404 page"
     }
   ]
 }

--- a/src/PPDS.Extension/src/constants/docsUrls.ts
+++ b/src/PPDS.Extension/src/constants/docsUrls.ts
@@ -7,6 +7,4 @@
 
 export const DOCS_URL = 'https://joshsmithxrm.github.io/ppds-docs/';
 
-// TODO(shakedown #8): Confirm whether a /plugin-registration/ subpath exists at the docs site
-// and update this constant to the specific page once confirmed.
-export const PLUGIN_REGISTRATION_DOCS_URL = `${DOCS_URL}plugin-registration/`;
+export const PLUGIN_REGISTRATION_DOCS_URL = DOCS_URL;


### PR DESCRIPTION
## Summary
- **Fixes #900** — Plugin Registration help button was opening a 404 (`/plugin-registration/` subpath doesn't exist on the docs site)
- Points `PLUGIN_REGISTRATION_DOCS_URL` to the main docs URL (`DOCS_URL`) as a fallback until the specific page is published
- Removes the stale `TODO(shakedown #8)` comment

## Test plan
- [x] Extension typecheck passes
- [x] All 438 extension unit tests pass
- [ ] Open Plugin Registration panel in VS Code, click help button — should open the main docs site (not a 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)