### PR TITLE
fix: enforce pipeline continuation after /gates and /verify

### DIFF
--- a/.claude/skills/gates/SKILL.md
+++ b/.claude/skills/gates/SKILL.md
@@ -170,6 +170,26 @@ python scripts/workflow-state.py set gates.passed now
 python scripts/workflow-state.py set gates.commit_ref "$(git rev-parse HEAD)"
 ```
 
+## Workflow Continuation — MANDATORY
+
+Gates are ONE step in the shipping pipeline — not the last one.
+
+After gates pass, check whether `/implement` is driving the pipeline:
+
+```bash
+python scripts/workflow-state.py get phase
+```
+
+- **If phase is `implementing`:** return gate results to the `/implement` orchestrator. It manages the remaining pipeline steps.
+- **Otherwise (standalone invocation):** you MUST continue the pipeline yourself. Do NOT stop after reporting gate results. Do NOT wait for the user to tell you what to do next. Execute the following chain:
+
+  1. `/verify` for each affected surface (extension, cli, tui, mcp)
+  2. `/pr` to create the pull request
+
+  **This is the #1 workflow failure mode** (retro R-01, 2026-04-24): reporting "all gates pass" and stopping. 3 of 9 PRs in v1.1 were never submitted because the AI stopped here. The chain is `/gates` → `/verify` → `/pr`. Execute it.
+
+Exception: if gates FAIL, stop and fix the failures first. Re-run `/gates` after fixing, then resume the chain.
+
 ## Rules
 
 1. **Mechanical only** — no subjective judgments, no code review, no style opinions

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -249,6 +249,23 @@ python scripts/workflow-state.py set verify.{surface}_commit_ref "$(git rev-pars
 Surface key matches mode: `ext`, `tui`, `mcp`, `cli`. Example: `/verify extension` → `verify.ext`.
 Surface key `workflow`: `/verify workflow` → writes `verify.workflow` (structural validation for process code).
 
+## Workflow Continuation — MANDATORY
+
+Verify is ONE step in the shipping pipeline — not the last one.
+
+After verify passes, check whether `/implement` is driving the pipeline:
+
+```bash
+python scripts/workflow-state.py get phase
+```
+
+- **If phase is `implementing`:** return verify results to the `/implement` orchestrator. It manages the remaining pipeline steps.
+- **Otherwise (standalone invocation):** proceed to `/pr` immediately. Do NOT stop after reporting verification results. Do NOT wait for the user to tell you what to do next.
+
+  The shipping pipeline is `/gates` → `/verify` → `/pr`. You are at step 2. Proceed to step 3.
+
+Exception: if verify FAILS, stop and fix the failures first. Re-run `/verify` after fixing, then proceed to `/pr`.
+
 ## Rules
 
 1. **Unit tests first** -- always. Don't waste interactive cycles on broken code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Agent topology, decision UX, lane assignment: **`.claude/interaction-patterns.md
 
 - Use Application Services for all persistent state — single code path for CLI / TUI / RPC.
 - Accept `IProgressReporter` for any operation likely to exceed 1 second.
+- Complete the shipping pipeline: `/gates` → `/verify` → `/pr`. Never stop after `/gates` or `/verify` — the work is not done until `/pr` creates the pull request.
 
 ## Testing
 

--- a/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
@@ -194,8 +194,7 @@ public class SolutionServiceTests
             BindingFlags.NonPublic | BindingFlags.Static);
         dictField.Should().NotBeNull("ComponentTypeNames dictionary should exist");
 
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>
-            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
+        var dict = dictField!.GetValue(null).Should().BeOfType<Dictionary<int, string>>().Subject;
         dict.Should().ContainKey(typeCode);
         dict[typeCode].Should().Be(expectedName);
     }
@@ -209,8 +208,7 @@ public class SolutionServiceTests
             BindingFlags.NonPublic | BindingFlags.Static);
         dictField.Should().NotBeNull();
 
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>
-            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
+        var dict = dictField!.GetValue(null).Should().BeOfType<Dictionary<int, string>>().Subject;
 
         foreach (var value in Enum.GetValues<PPDS.Dataverse.Generated.componenttype>())
         {
@@ -228,8 +226,7 @@ public class SolutionServiceTests
         var dictField = typeof(SolutionService).GetField(
             "ComponentTypeNames",
             BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>
-            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
+        var dict = dictField!.GetValue(null).Should().BeOfType<Dictionary<int, string>>().Subject;
 
         dict.Should().ContainKey(80);
         dict[80].Should().Be("Model-Driven App");
@@ -242,8 +239,7 @@ public class SolutionServiceTests
         var dictField = typeof(SolutionService).GetField(
             "ComponentTypeNames",
             BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>
-            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
+        var dict = dictField!.GetValue(null).Should().BeOfType<Dictionary<int, string>>().Subject;
 
         // Connector1 (372) should display as "Connector", not the auto-generated "Connector1"
         dict.Should().ContainKey(372);

--- a/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Solutions/SolutionServiceTests.cs
@@ -194,10 +194,10 @@ public class SolutionServiceTests
             BindingFlags.NonPublic | BindingFlags.Static);
         dictField.Should().NotBeNull("ComponentTypeNames dictionary should exist");
 
-        var dict = dictField!.GetValue(null) as Dictionary<int, string>;
-        dict.Should().NotBeNull();
+        var dict = dictField!.GetValue(null) as Dictionary<int, string>
+            ?? throw new InvalidOperationException("ComponentTypeNames must be Dictionary<int, string>");
         dict.Should().ContainKey(typeCode);
-        dict![typeCode].Should().Be(expectedName);
+        dict[typeCode].Should().Be(expectedName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **R-01 fix:** Add "Workflow Continuation — MANDATORY" sections to `/gates` and `/verify` skills that instruct the AI to continue the shipping pipeline (`/gates` → `/verify` → `/pr`) instead of stopping after reporting results. The continuation is phase-aware — defers to `/implement` when the orchestrator is driving. Adds an ALWAYS rule to CLAUDE.md reinforcing the full chain.
- **R-03 fix:** Replace nullable `as` cast with `?? throw` pattern in `SolutionServiceTests.ComponentTypeNames_MatchesGeneratedEnum` to eliminate CodeQL `cs/dereferenced-value-may-be-null` alert #1238.

### Root cause (R-01)

The `/gates` and `/verify` skills both ended with "report results" framing and "no fixes" rules, but contained NO instruction to continue to the next workflow step. The `/start` routing correctly says `/gates` → `/verify` → `/pr`, but once the AI enters `/gates`, the skill's own instructions end at reporting. 3 of 9 PRs in v1.1 were never submitted because the AI stopped after gates.

## Test Plan

- [x] All 44 SolutionServiceTests pass across net8.0/net9.0/net10.0
- [x] All 32 skill frontmatter validations pass
- [x] All 9 workflow behavioral scenarios pass
- [x] All 14 hook scripts exit cleanly
- [x] .NET build: 0 errors
- [x] TypeScript build + typecheck: 0 errors
- [x] TypeScript tests: 438/438 pass

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)