### PR TITLE
feat(extension): add entity configuration tab and global optionset details

### DIFF
--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -1621,8 +1621,24 @@ public class RpcMethodHandler : IDisposable
             Description = entity.Description,
             PrimaryIdAttribute = entity.PrimaryIdAttribute,
             PrimaryNameAttribute = entity.PrimaryNameAttribute,
+            PrimaryImageAttribute = entity.PrimaryImageAttribute,
             EntitySetName = entity.EntitySetName,
+            LogicalCollectionName = entity.LogicalCollectionName,
+            PluralName = entity.PluralName,
             IsActivity = entity.IsActivity,
+            IsActivityParty = entity.IsActivityParty,
+            HasNotes = entity.HasNotes,
+            HasActivities = entity.HasActivities,
+            IsValidForAdvancedFind = entity.IsValidForAdvancedFind,
+            IsAuditEnabled = entity.IsAuditEnabled,
+            ChangeTrackingEnabled = entity.ChangeTrackingEnabled,
+            IsBusinessProcessEnabled = entity.IsBusinessProcessEnabled,
+            IsQuickCreateEnabled = entity.IsQuickCreateEnabled,
+            IsDuplicateDetectionEnabled = entity.IsDuplicateDetectionEnabled,
+            IsValidForQueue = entity.IsValidForQueue,
+            IsIntersect = entity.IsIntersect,
+            CanCreateMultiple = entity.CanCreateMultiple,
+            CanUpdateMultiple = entity.CanUpdateMultiple,
             Attributes = entity.Attributes.Select(MapAttributeToRpc).ToList(),
             OneToManyRelationships = entity.OneToManyRelationships.Select(MapRelationshipToRpc).ToList(),
             ManyToOneRelationships = entity.ManyToOneRelationships.Select(MapRelationshipToRpc).ToList(),
@@ -1731,6 +1747,9 @@ public class RpcMethodHandler : IDisposable
             DisplayName = os.DisplayName,
             OptionSetType = os.OptionSetType,
             IsGlobal = os.IsGlobal,
+            IsCustomOptionSet = os.IsCustomOptionSet,
+            IsManaged = os.IsManaged,
+            Description = os.Description,
             Options = os.Options.Select(MapOptionValueToRpc).ToList()
         };
     }
@@ -7153,8 +7172,59 @@ public class MetadataEntityDetailDto
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? EntitySetName { get; set; }
 
+    [JsonPropertyName("primaryImageAttribute")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrimaryImageAttribute { get; set; }
+
+    [JsonPropertyName("logicalCollectionName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LogicalCollectionName { get; set; }
+
+    [JsonPropertyName("pluralName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PluralName { get; set; }
+
     [JsonPropertyName("isActivity")]
     public bool IsActivity { get; set; }
+
+    [JsonPropertyName("isActivityParty")]
+    public bool IsActivityParty { get; set; }
+
+    [JsonPropertyName("hasNotes")]
+    public bool HasNotes { get; set; }
+
+    [JsonPropertyName("hasActivities")]
+    public bool HasActivities { get; set; }
+
+    [JsonPropertyName("isValidForAdvancedFind")]
+    public bool IsValidForAdvancedFind { get; set; }
+
+    [JsonPropertyName("isAuditEnabled")]
+    public bool IsAuditEnabled { get; set; }
+
+    [JsonPropertyName("changeTrackingEnabled")]
+    public bool ChangeTrackingEnabled { get; set; }
+
+    [JsonPropertyName("isBusinessProcessEnabled")]
+    public bool IsBusinessProcessEnabled { get; set; }
+
+    [JsonPropertyName("isQuickCreateEnabled")]
+    public bool IsQuickCreateEnabled { get; set; }
+
+    [JsonPropertyName("isDuplicateDetectionEnabled")]
+    public bool IsDuplicateDetectionEnabled { get; set; }
+
+    [JsonPropertyName("isValidForQueue")]
+    public bool IsValidForQueue { get; set; }
+
+    [JsonPropertyName("isIntersect")]
+    public bool IsIntersect { get; set; }
+
+    [JsonPropertyName("canCreateMultiple")]
+    public bool CanCreateMultiple { get; set; }
+
+    [JsonPropertyName("canUpdateMultiple")]
+    public bool CanUpdateMultiple { get; set; }
 
     [JsonPropertyName("attributes")]
     public List<MetadataAttributeDto> Attributes { get; set; } = [];
@@ -7392,6 +7462,16 @@ public class MetadataOptionSetDto
 
     [JsonPropertyName("isGlobal")]
     public bool IsGlobal { get; set; }
+
+    [JsonPropertyName("isCustomOptionSet")]
+    public bool IsCustomOptionSet { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
 
     [JsonPropertyName("options")]
     public List<MetadataOptionValueDto> Options { get; set; } = [];

--- a/src/PPDS.Extension/src/__tests__/panels/metadataBrowserPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/metadataBrowserPanel.test.ts
@@ -76,13 +76,21 @@ describe('MetadataBrowserPanel message types', () => {
                 { command: 'updateEnvironment', name: 'dev', envType: 'Sandbox', envColor: '#00ff00' },
                 { command: 'entitiesLoaded', entities: [], intersectHiddenCount: 0 },
                 { command: 'globalChoicesLoaded', choices: [] },
-                { command: 'globalChoiceDetailLoaded', choice: { name: 'statuscode', displayName: 'Status', optionSetType: 'Picklist', isGlobal: true, options: [] } },
+                { command: 'globalChoiceDetailLoaded', choice: { name: 'statuscode', displayName: 'Status', optionSetType: 'Picklist', isGlobal: true, isCustomOptionSet: false, isManaged: true, description: null, options: [] } },
                 { command: 'entityDetailLoaded', entity: {
                     logicalName: 'account', schemaName: 'Account', displayName: 'Account',
                     isCustomEntity: false, isManaged: false, ownershipType: 'UserOwned',
                     objectTypeCode: 1, description: null,
                     primaryIdAttribute: 'accountid', primaryNameAttribute: 'name',
-                    entitySetName: 'accounts', isActivity: false,
+                    primaryImageAttribute: null, entitySetName: 'accounts',
+                    logicalCollectionName: 'accounts', pluralName: 'Accounts',
+                    isActivity: false, isActivityParty: false,
+                    hasNotes: true, hasActivities: true,
+                    isValidForAdvancedFind: true, isAuditEnabled: false,
+                    changeTrackingEnabled: false, isBusinessProcessEnabled: false,
+                    isQuickCreateEnabled: true, isDuplicateDetectionEnabled: true,
+                    isValidForQueue: false, isIntersect: false,
+                    canCreateMultiple: true, canUpdateMultiple: true,
                     attributes: [], oneToManyRelationships: [], manyToOneRelationships: [],
                     manyToManyRelationships: [], keys: [], privileges: [], globalOptionSets: [],
                 } },
@@ -199,6 +207,9 @@ describe('MetadataBrowserPanel message types', () => {
                 displayName: 'Status Reason',
                 optionSetType: 'Status',
                 isGlobal: true,
+                isCustomOptionSet: false,
+                isManaged: true,
+                description: 'Status reason for the record',
                 options: [
                     { value: 1, label: 'Active', color: '#00ff00', description: null },
                     { value: 2, label: 'Inactive', color: null, description: 'Record is inactive' },
@@ -206,6 +217,9 @@ describe('MetadataBrowserPanel message types', () => {
             };
             expect(dto.name).toBe('statuscode');
             expect(dto.isGlobal).toBe(true);
+            expect(dto.isCustomOptionSet).toBe(false);
+            expect(dto.isManaged).toBe(true);
+            expect(dto.description).toBe('Status reason for the record');
             expect(dto.options).toHaveLength(2);
             expect(dto.options[0].label).toBe('Active');
         });
@@ -216,6 +230,9 @@ describe('MetadataBrowserPanel message types', () => {
                 displayName: null,
                 optionSetType: 'Picklist',
                 isGlobal: false,
+                isCustomOptionSet: true,
+                isManaged: false,
+                description: null,
                 options: [],
             };
             expect(dto.options).toHaveLength(0);
@@ -235,8 +252,24 @@ describe('MetadataBrowserPanel message types', () => {
                 description: null,
                 primaryIdAttribute: 'accountid',
                 primaryNameAttribute: 'name',
+                primaryImageAttribute: 'entityimage',
                 entitySetName: 'accounts',
+                logicalCollectionName: 'accounts',
+                pluralName: 'Accounts',
                 isActivity: false,
+                isActivityParty: false,
+                hasNotes: true,
+                hasActivities: true,
+                isValidForAdvancedFind: true,
+                isAuditEnabled: true,
+                changeTrackingEnabled: false,
+                isBusinessProcessEnabled: false,
+                isQuickCreateEnabled: true,
+                isDuplicateDetectionEnabled: true,
+                isValidForQueue: false,
+                isIntersect: false,
+                canCreateMultiple: true,
+                canUpdateMultiple: true,
                 attributes: [
                     {
                         logicalName: 'name',
@@ -273,8 +306,14 @@ describe('MetadataBrowserPanel message types', () => {
             };
             expect(dto.primaryIdAttribute).toBe('accountid');
             expect(dto.primaryNameAttribute).toBe('name');
+            expect(dto.primaryImageAttribute).toBe('entityimage');
+            expect(dto.logicalCollectionName).toBe('accounts');
+            expect(dto.pluralName).toBe('Accounts');
             expect(dto.entitySetName).toBe('accounts');
             expect(dto.isActivity).toBe(false);
+            expect(dto.isAuditEnabled).toBe(true);
+            expect(dto.canCreateMultiple).toBe(true);
+            expect(dto.hasNotes).toBe(true);
             expect(dto.attributes).toHaveLength(1);
             expect(dto.attributes[0].isPrimaryName).toBe(true);
         });

--- a/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
@@ -258,7 +258,8 @@
 .rel-table-wrapper,
 .keys-table-wrapper,
 .priv-table-wrapper,
-.choice-detail-wrapper {
+.choice-detail-wrapper,
+.config-grid-wrapper {
     flex: 1;
     overflow: auto;
     min-height: 0;
@@ -505,6 +506,17 @@
 }
 
 /* ── Global choice detail ──────────────────────────────────────────────── */
+
+.choice-detail-wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.choice-table-container {
+    flex: 1;
+    overflow: auto;
+    min-height: 0;
+}
 
 .choice-summary {
     padding: 8px 12px;

--- a/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
@@ -55,10 +55,11 @@ const tabSearchTerms: Record<string, string> = {};
 let entitiesSectionCollapsed = false;
 let choicesSectionCollapsed = false;
 
-type TabId = 'attributes' | '1n' | 'n1' | 'nn' | 'keys' | 'privileges' | 'choices' | 'choice-detail';
+type TabId = 'attributes' | 'config' | '1n' | 'n1' | 'nn' | 'keys' | 'privileges' | 'choices' | 'choice-detail';
 
 const ENTITY_TAB_DEFS: { id: TabId; label: string }[] = [
     { id: 'attributes', label: 'Attributes' },
+    { id: 'config', label: 'Configuration' },
     { id: '1n', label: '1:N' },
     { id: 'n1', label: 'N:1' },
     { id: 'nn', label: 'N:N' },
@@ -484,6 +485,9 @@ function renderTabContent(): void {
         case 'attributes':
             renderAttributesTab();
             break;
+        case 'config':
+            renderConfigTab();
+            break;
         case '1n':
             renderOneToManyTab();
             break;
@@ -752,6 +756,84 @@ function showAttributePropertiesPanel(attr: MetadataAttributeDto, container: HTM
     }
 
     container.appendChild(panel);
+}
+
+// ── Configuration tab ──
+function renderConfigTab(): void {
+    if (!currentEntity) return;
+    tabContent.innerHTML = '';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'config-grid-wrapper';
+
+    const sections: { title: string; rows: [string, string][] }[] = [
+        {
+            title: 'Identity',
+            rows: [
+                ['Plural Name', currentEntity.pluralName ?? '—'],
+                ['Logical Collection Name', currentEntity.logicalCollectionName ?? '—'],
+                ['Primary Image Attribute', currentEntity.primaryImageAttribute ?? '—'],
+            ],
+        },
+        {
+            title: 'Features',
+            rows: [
+                ['Quick Create Enabled', currentEntity.isQuickCreateEnabled ? '✓' : '—'],
+                ['Duplicate Detection Enabled', currentEntity.isDuplicateDetectionEnabled ? '✓' : '—'],
+                ['Valid for Queue', currentEntity.isValidForQueue ? '✓' : '—'],
+                ['Valid for Advanced Find', currentEntity.isValidForAdvancedFind ? '✓' : '—'],
+                ['Business Process Enabled', currentEntity.isBusinessProcessEnabled ? '✓' : '—'],
+            ],
+        },
+        {
+            title: 'Auditing & Tracking',
+            rows: [
+                ['Audit Enabled', currentEntity.isAuditEnabled ? '✓' : '—'],
+                ['Change Tracking Enabled', currentEntity.changeTrackingEnabled ? '✓' : '—'],
+            ],
+        },
+        {
+            title: 'Relationships',
+            rows: [
+                ['Has Notes', currentEntity.hasNotes ? '✓' : '—'],
+                ['Has Activities', currentEntity.hasActivities ? '✓' : '—'],
+                ['Is Activity Party', currentEntity.isActivityParty ? '✓' : '—'],
+                ['Is Intersect', currentEntity.isIntersect ? '✓' : '—'],
+            ],
+        },
+        {
+            title: 'Bulk API Support',
+            rows: [
+                ['Can Create Multiple', currentEntity.canCreateMultiple ? '✓' : '—'],
+                ['Can Update Multiple', currentEntity.canUpdateMultiple ? '✓' : '—'],
+            ],
+        },
+    ];
+
+    for (const section of sections) {
+        const header = document.createElement('div');
+        header.className = 'prop-section-header';
+        header.textContent = section.title;
+        wrapper.appendChild(header);
+
+        const table = document.createElement('table');
+        table.className = 'prop-panel-table';
+        for (const [label, value] of section.rows) {
+            const tr = document.createElement('tr');
+            const labelTd = document.createElement('td');
+            labelTd.className = 'prop-label';
+            labelTd.textContent = label;
+            tr.appendChild(labelTd);
+            const valueTd = document.createElement('td');
+            valueTd.className = 'prop-value';
+            valueTd.textContent = value;
+            tr.appendChild(valueTd);
+            table.appendChild(tr);
+        }
+        wrapper.appendChild(table);
+    }
+
+    tabContent.appendChild(wrapper);
 }
 
 // ── 1:N Relationships tab ──
@@ -1363,8 +1445,11 @@ function renderGlobalChoiceOptionsTable(container: HTMLElement): void {
         ['Display Name', currentGlobalChoice!.displayName || '\u2014'],
         ['Name', currentGlobalChoice!.name],
         ['Type', currentGlobalChoice!.optionSetType],
+        ['Description', currentGlobalChoice!.description || '\u2014'],
         ['Options', String(currentGlobalChoice!.options.length)],
         ['Is Global', 'Yes'],
+        ['Is Custom', currentGlobalChoice!.isCustomOptionSet ? 'Yes' : 'No'],
+        ['Is Managed', currentGlobalChoice!.isManaged ? 'Yes' : 'No'],
     ];
     for (const [label, value] of props) {
         const row = document.createElement('div');
@@ -1395,8 +1480,12 @@ function renderGlobalChoiceOptionsTable(container: HTMLElement): void {
         );
     }
 
+    const tableContainer = document.createElement('div');
+    tableContainer.className = 'choice-table-container';
+    wrapper.appendChild(tableContainer);
+
     const table = new DataTable<OptionValueRow>({
-        container: wrapper,
+        container: tableContainer,
         columns: [
             { key: 'value', label: 'Value', render: (o) => escapeHtml(String(o.value)) },
             { key: 'label', label: 'Label', render: (o) => escapeHtml(o.label) },

--- a/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
@@ -770,42 +770,42 @@ function renderConfigTab(): void {
         {
             title: 'Identity',
             rows: [
-                ['Plural Name', currentEntity.pluralName ?? '—'],
-                ['Logical Collection Name', currentEntity.logicalCollectionName ?? '—'],
-                ['Primary Image Attribute', currentEntity.primaryImageAttribute ?? '—'],
+                ['Plural Name', currentEntity.pluralName ?? '\u2014'],
+                ['Logical Collection Name', currentEntity.logicalCollectionName ?? '\u2014'],
+                ['Primary Image Attribute', currentEntity.primaryImageAttribute ?? '\u2014'],
             ],
         },
         {
             title: 'Features',
             rows: [
-                ['Quick Create Enabled', currentEntity.isQuickCreateEnabled ? '✓' : '—'],
-                ['Duplicate Detection Enabled', currentEntity.isDuplicateDetectionEnabled ? '✓' : '—'],
-                ['Valid for Queue', currentEntity.isValidForQueue ? '✓' : '—'],
-                ['Valid for Advanced Find', currentEntity.isValidForAdvancedFind ? '✓' : '—'],
-                ['Business Process Enabled', currentEntity.isBusinessProcessEnabled ? '✓' : '—'],
+                ['Quick Create Enabled', currentEntity.isQuickCreateEnabled ? '\u2713' : '\u2014'],
+                ['Duplicate Detection Enabled', currentEntity.isDuplicateDetectionEnabled ? '\u2713' : '\u2014'],
+                ['Valid for Queue', currentEntity.isValidForQueue ? '\u2713' : '\u2014'],
+                ['Valid for Advanced Find', currentEntity.isValidForAdvancedFind ? '\u2713' : '\u2014'],
+                ['Business Process Enabled', currentEntity.isBusinessProcessEnabled ? '\u2713' : '\u2014'],
             ],
         },
         {
             title: 'Auditing & Tracking',
             rows: [
-                ['Audit Enabled', currentEntity.isAuditEnabled ? '✓' : '—'],
-                ['Change Tracking Enabled', currentEntity.changeTrackingEnabled ? '✓' : '—'],
+                ['Audit Enabled', currentEntity.isAuditEnabled ? '\u2713' : '\u2014'],
+                ['Change Tracking Enabled', currentEntity.changeTrackingEnabled ? '\u2713' : '\u2014'],
             ],
         },
         {
             title: 'Relationships',
             rows: [
-                ['Has Notes', currentEntity.hasNotes ? '✓' : '—'],
-                ['Has Activities', currentEntity.hasActivities ? '✓' : '—'],
-                ['Is Activity Party', currentEntity.isActivityParty ? '✓' : '—'],
-                ['Is Intersect', currentEntity.isIntersect ? '✓' : '—'],
+                ['Has Notes', currentEntity.hasNotes ? '\u2713' : '\u2014'],
+                ['Has Activities', currentEntity.hasActivities ? '\u2713' : '\u2014'],
+                ['Is Activity Party', currentEntity.isActivityParty ? '\u2713' : '\u2014'],
+                ['Is Intersect', currentEntity.isIntersect ? '\u2713' : '\u2014'],
             ],
         },
         {
             title: 'Bulk API Support',
             rows: [
-                ['Can Create Multiple', currentEntity.canCreateMultiple ? '✓' : '—'],
-                ['Can Update Multiple', currentEntity.canUpdateMultiple ? '✓' : '—'],
+                ['Can Create Multiple', currentEntity.canCreateMultiple ? '\u2713' : '\u2014'],
+                ['Can Update Multiple', currentEntity.canUpdateMultiple ? '\u2713' : '\u2014'],
             ],
         },
     ];

--- a/src/PPDS.Extension/src/types.ts
+++ b/src/PPDS.Extension/src/types.ts
@@ -316,8 +316,24 @@ export interface MetadataEntityResponse {
 export interface MetadataEntityDetailDto extends MetadataEntitySummaryDto {
     primaryIdAttribute: string | null;
     primaryNameAttribute: string | null;
+    primaryImageAttribute: string | null;
     entitySetName: string | null;
+    logicalCollectionName: string | null;
+    pluralName: string | null;
     isActivity: boolean;
+    isActivityParty: boolean;
+    hasNotes: boolean;
+    hasActivities: boolean;
+    isValidForAdvancedFind: boolean;
+    isAuditEnabled: boolean;
+    changeTrackingEnabled: boolean;
+    isBusinessProcessEnabled: boolean;
+    isQuickCreateEnabled: boolean;
+    isDuplicateDetectionEnabled: boolean;
+    isValidForQueue: boolean;
+    isIntersect: boolean;
+    canCreateMultiple: boolean;
+    canUpdateMultiple: boolean;
     attributes: MetadataAttributeDto[];
     oneToManyRelationships: MetadataRelationshipDto[];
     manyToOneRelationships: MetadataRelationshipDto[];
@@ -402,6 +418,9 @@ export interface MetadataOptionSetDto {
     displayName: string | null;
     optionSetType: string;
     isGlobal: boolean;
+    isCustomOptionSet: boolean;
+    isManaged: boolean;
+    description: string | null;
     options: MetadataOptionValueDto[];
 }
 


### PR DESCRIPTION
## Summary
- Add **Configuration** tab to Metadata Browser showing 16 entity settings across 5 sections: Identity, Features, Auditing & Tracking, Relationships, and Bulk API Support
- Surface **description**, **isManaged**, and **isCustomOptionSet** on global optionset detail view
- Wire missing fields through the daemon RPC layer (DTOs + mapping) and fix pre-existing bug where DataTable cleared the choice summary div

Closes #901

## Test Plan
- [x] TypeScript compiles cleanly (host + webview)
- [x] All 438 extension unit tests pass
- [x] All 16,455 .NET tests pass
- [x] Configuration tab renders with real Dataverse data (account entity shows Plural Name, entityimage, checkmarks for enabled features)
- [x] Global choice detail shows Description, Is Custom, Is Managed with real values
- [x] No runtime errors in PPDS output channel

## Verification
- [x] /gates passed (all gates green)
- [x] /verify completed (surfaces: extension)
- [x] /review completed (findings: 0 defects, 2 concerns, 1 nit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)