### PR TITLE
feat: wire up live docs-release pipeline

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -8,9 +8,8 @@ name: docs-release
 # Spec: specs/docs-generation.md — Primary Flows "Release tag ships docs" +
 # AC-25, AC-26, AC-27, AC-30.
 #
-# The live PR-creation steps are TODO — GitHub App installation is tracked as
-# a runbook item (Phase 5 §5.1). The dry-run path (workflow_dispatch with
-# dry_run=true) exercises every generator end-to-end and uploads artifacts.
+# The dry-run path (workflow_dispatch with dry_run=true) exercises every
+# generator end-to-end and uploads artifacts without opening PRs.
 
 on:
   push:
@@ -24,8 +23,8 @@ on:
         default: false
 
 permissions:
-  contents: read
-  pull-requests: read
+  contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -94,26 +93,15 @@ jobs:
           name: docs-release-dry-run
           path: artifacts/
 
-      # ----------------------------------------------------------------
-      # Live PR creation — TODO: requires GitHub App installed on ppds +
-      # ppds-docs. Runbook: scripts/docs-gen/README.md (Phase 6).
-      # ----------------------------------------------------------------
-
       - name: Get GitHub App token
         if: ${{ inputs.dry_run != true }}
         id: app-token
         env:
-          APP_ID: ${{ secrets.PPDS_DOCS_APP_ID }}
+          APP_ID: ${{ vars.PPDS_DOCS_APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.PPDS_DOCS_APP_PRIVATE_KEY }}
         run: |
-          # TODO: once the PPDS_DOCS_APP_ID / PPDS_DOCS_APP_PRIVATE_KEY
-          # secrets are configured on this repo, invoke the helper:
-          #   TOKEN=$(dotnet run --project scripts/docs-gen/app-token -c Release)
-          #   echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
-          # Until then, skip cleanly so the workflow remains valid without
-          # halting on a missing secret.
-          echo "app-token: GitHub App not configured; skipping live PR step" >&2
-          echo "token=" >> "$GITHUB_OUTPUT"
+          TOKEN=$(dotnet run --project scripts/docs-gen/app-token -c Release)
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Open ppds-docs PR
         if: ${{ inputs.dry_run != true && steps.app-token.outputs.token != '' }}
@@ -122,20 +110,11 @@ jobs:
           TAG_REF: ${{ github.ref_name }}
           RUN_ID: ${{ github.run_id }}
           DOCS_REPO: ${{ vars.PPDS_DOCS_REPO }}
-        run: |
-          # TODO: write artifacts/docs/** into a fresh branch in ppds-docs,
-          # push, and open a PR with artifacts/pr-body.md as the body. Until
-          # the open-docs-pr.sh helper exists this is a no-op.
-          echo "open-docs-pr: TODO — would push to $DOCS_REPO on branch docs/release-$TAG_REF" >&2
+        run: bash scripts/docs-gen/open-docs-pr.sh
 
       - name: Open baseline rollover PR
         if: ${{ inputs.dry_run != true }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_REF: ${{ github.ref_name }}
-        run: |
-          # TODO: run compute-rollover-diff.sh, stage the modified
-          # PublicAPI.{Shipped,Unshipped}.txt files, push a branch, and open
-          # a PR titled "chore(release): $TAG_REF baseline rollover". Until
-          # the open-rollover-pr.sh helper exists this is a no-op.
-          echo "open-rollover-pr: TODO — would open rollover PR for $TAG_REF" >&2
+        run: bash scripts/docs-gen/open-rollover-pr.sh

--- a/scripts/docs-gen/app-token/Program.cs
+++ b/scripts/docs-gen/app-token/Program.cs
@@ -34,7 +34,7 @@ public static class Program
     /// <summary>Target installation account — the token is minted for the
     /// app installation on this GitHub account/org's <c>ppds-docs</c> repo.
     /// </summary>
-    private const string TargetInstallationLogin = "ppds-docs";
+    private const string TargetInstallationLogin = "joshsmithxrm";
 
     /// <summary>
     /// Entry point.

--- a/scripts/docs-gen/open-docs-pr.sh
+++ b/scripts/docs-gen/open-docs-pr.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# open-docs-pr.sh — clone ppds-docs, write generated reference markdown,
+# push a branch, and open a PR.
+#
+# Env (all set by the workflow):
+#   GITHUB_TOKEN   GitHub App installation token with contents:write +
+#                  pull-requests:write on the docs repo.
+#   DOCS_REPO      Owner/name of the docs repo (e.g. joshsmithxrm/ppds-docs).
+#   TAG_REF        The release tag that triggered the workflow (e.g. v1.1.0).
+#   RUN_ID         GitHub Actions run ID (used for branch uniqueness).
+#
+# Expects artifacts/docs/ to contain the generated reference markdown and
+# artifacts/pr-body.md to contain the surface-change summary.
+
+set -euo pipefail
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "open-docs-pr: GITHUB_TOKEN is required" >&2
+  exit 1
+fi
+if [ -z "${DOCS_REPO:-}" ]; then
+  echo "open-docs-pr: DOCS_REPO is required" >&2
+  exit 1
+fi
+if [ -z "${TAG_REF:-}" ]; then
+  echo "open-docs-pr: TAG_REF is required" >&2
+  exit 1
+fi
+if [ -z "${RUN_ID:-}" ]; then
+  echo "open-docs-pr: RUN_ID is required" >&2
+  exit 1
+fi
+
+BRANCH="release/${TAG_REF}-ref-${RUN_ID}"
+CLONE_DIR="$(mktemp -d)"
+
+echo "open-docs-pr: cloning $DOCS_REPO into $CLONE_DIR" >&2
+git clone --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${DOCS_REPO}.git" "$CLONE_DIR"
+
+echo "open-docs-pr: creating branch $BRANCH" >&2
+git -C "$CLONE_DIR" checkout -b "$BRANCH"
+
+echo "open-docs-pr: copying generated docs to $CLONE_DIR/docs/reference/" >&2
+mkdir -p "$CLONE_DIR/docs/reference"
+cp -r artifacts/docs/reference/* "$CLONE_DIR/docs/reference/"
+
+git -C "$CLONE_DIR" add docs/reference/
+CHANGES=$(git -C "$CLONE_DIR" diff --cached --name-only)
+
+if [ -z "$CHANGES" ]; then
+  echo "open-docs-pr: no reference changes to push — skipping PR" >&2
+  rm -rf "$CLONE_DIR"
+  exit 0
+fi
+
+echo "open-docs-pr: committing $(echo "$CHANGES" | wc -l | tr -d ' ') file(s)" >&2
+git -C "$CLONE_DIR" \
+  -c user.name="ppds-docs-bot" \
+  -c user.email="ppds-docs-bot[bot]@users.noreply.github.com" \
+  commit -m "chore(reference): regenerate for $TAG_REF"
+
+echo "open-docs-pr: pushing $BRANCH" >&2
+git -C "$CLONE_DIR" push origin "$BRANCH"
+
+PR_TITLE="chore(reference): regenerate for $TAG_REF"
+PR_BODY="$(cat artifacts/pr-body.md 2>/dev/null || echo "Reference docs regenerated from $TAG_REF.")"
+
+echo "open-docs-pr: opening PR on $DOCS_REPO" >&2
+PR_URL=$(GH_TOKEN="$GITHUB_TOKEN" gh pr create \
+  --repo "$DOCS_REPO" \
+  --base main \
+  --head "$BRANCH" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY")
+
+echo "open-docs-pr: created $PR_URL" >&2
+rm -rf "$CLONE_DIR"

--- a/scripts/docs-gen/open-rollover-pr.sh
+++ b/scripts/docs-gen/open-rollover-pr.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# open-rollover-pr.sh — run the baseline rollover, push a branch, and open a
+# PR that moves PublicAPI.Unshipped entries to Shipped.
+#
+# Env (all set by the workflow):
+#   GITHUB_TOKEN   Token with contents:write + pull-requests:write on this repo.
+#   TAG_REF        The release tag that triggered the workflow (e.g. v1.1.0).
+#
+# Must be run from the repo root (the workflow checkout).
+
+set -euo pipefail
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "open-rollover-pr: GITHUB_TOKEN is required" >&2
+  exit 1
+fi
+if [ -z "${TAG_REF:-}" ]; then
+  echo "open-rollover-pr: TAG_REF is required" >&2
+  exit 1
+fi
+
+BRANCH="chore/rollover-${TAG_REF}"
+
+echo "open-rollover-pr: running compute-rollover-diff.sh" >&2
+CHANGED_FILES=$(bash scripts/docs-gen/compute-rollover-diff.sh)
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "open-rollover-pr: no Unshipped entries to roll — skipping PR" >&2
+  exit 0
+fi
+
+echo "open-rollover-pr: creating branch $BRANCH" >&2
+git checkout -b "$BRANCH"
+
+echo "open-rollover-pr: staging changed files" >&2
+echo "$CHANGED_FILES" | while IFS= read -r f; do
+  [ -n "$f" ] && git add "$f"
+done
+
+git \
+  -c user.name="github-actions[bot]" \
+  -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+  commit -m "chore(release): $TAG_REF baseline rollover"
+
+echo "open-rollover-pr: pushing $BRANCH" >&2
+git push origin "$BRANCH"
+
+PR_TITLE="chore(release): $TAG_REF baseline rollover"
+PR_BODY="Moves PublicAPI.Unshipped.txt entries to Shipped.txt for the $TAG_REF release.
+
+Merge this **before** the ppds-docs PR so future release diffs have a clean baseline."
+
+echo "open-rollover-pr: opening PR" >&2
+PR_URL=$(gh pr create \
+  --base main \
+  --head "$BRANCH" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY")
+
+echo "open-rollover-pr: created $PR_URL" >&2


### PR DESCRIPTION
## Summary
- Activates the live PR-creation path in the docs-release workflow (previously all three steps were stubbed)
- **Fixes:** `app-token` TargetInstallationLogin was `"ppds-docs"` (repo name) instead of `"joshsmithxrm"` (account login) — would never find the installation
- **Fixes:** `APP_ID` was referenced as `secrets.PPDS_DOCS_APP_ID` but it's stored as a variable (`vars.`)
- **Adds** `open-docs-pr.sh` — clones ppds-docs, writes generated reference markdown, pushes branch, opens PR
- **Adds** `open-rollover-pr.sh` — runs baseline rollover, pushes branch, opens PR
- Upgrades workflow permissions from `read` to `write` for `contents` and `pull-requests` (needed to push branches and open PRs)

## Prerequisites completed
- [x] GitHub App created (PPDS Docs Bot, App ID 3496164)
- [x] App installed on both `power-platform-developer-suite` and `ppds-docs`
- [x] `PPDS_DOCS_APP_PRIVATE_KEY` secret configured
- [x] `PPDS_DOCS_APP_ID` variable configured
- [x] `PPDS_DOCS_REPO` variable configured

## Test plan
- [ ] Merge, then run `gh workflow run docs-release.yml -f dry_run=true` to verify generators still work
- [ ] Tag a test release to validate the full live path (app token minting → ppds-docs PR → rollover PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)