### PR TITLE
fix(monitor): fetch feature branch before push to prevent stale ref (#929)

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -574,7 +574,23 @@ def _rebase_source_branch(worktree, pr_number, logger):
         _pop_stash()
         return False
 
-    # 5. Push with lease using explicit origin + HEAD:<branch> refspec.
+    # 5. Fetch the feature branch so the local tracking ref is current.
+    #    Without this, --force-with-lease rejects the push when another
+    #    process (e.g. the triage agent) has pushed to the remote since
+    #    this worktree last fetched.
+    try:
+        fetch_src = _run(["git", "fetch", "origin", "--", current])
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.log("rebase", "FETCH_SOURCE_ERROR", reason=str(e), branch=current)
+        _pop_stash()
+        return False
+    if fetch_src.returncode != 0:
+        logger.log("rebase", "FETCH_SOURCE_ERROR", branch=current,
+                   stderr=fetch_src.stderr.strip()[:200])
+        _pop_stash()
+        return False
+
+    # 6. Push with lease using explicit origin + HEAD:<branch> refspec.
     try:
         push = _run(
             ["git", "push", "--force-with-lease", "origin", f"HEAD:{current}"],

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -891,9 +891,20 @@ def run_notify(worktree, pr_number, logger, message=None):
 STEPS = ["ci", "gemini", "triage", "ready", "retro", "notify"]
 
 
+_SUCCESS_STATUSES = frozenset({"done", "pass"})
+
+
 def step_completed(result, step_name):
-    """Check if a step was already completed (for --resume)."""
-    return result.get("steps_completed", {}).get(step_name) is not None
+    """Check if a step completed successfully (for --resume).
+
+    Only terminal success statuses count. Failed/skipped/errored steps
+    are retried on resume — the conditions that caused the failure may
+    have changed (e.g. dirty files cleaned up, new commits pushed).
+    """
+    step = result.get("steps_completed", {}).get(step_name)
+    if step is None:
+        return False
+    return step.get("status") in _SUCCESS_STATUSES
 
 
 def mark_step(result, step_name, status):

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -516,8 +516,11 @@ def _rebase_source_branch(worktree, pr_number, logger):
     try:
         status = _run(["git", "status", "--porcelain"])
         if status.returncode == 0 and status.stdout.strip():
+            # Exclude untracked (??) files — they don't block rebase and
+            # shouldn't poison the safety check for modified files.
             dirty = [l.strip().split(maxsplit=1)[-1].strip('"')
-                     for l in status.stdout.strip().splitlines() if l.strip()]
+                     for l in status.stdout.strip().splitlines()
+                     if l.strip() and not l.strip().startswith("??")]
             safe = all(any(f.startswith(p) for p in _STASHABLE) for f in dirty)
             if safe and dirty:
                 stash = _run(["git", "stash", "push", "-m", "pr-monitor-rebase",

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -511,7 +511,7 @@ def _rebase_source_branch(worktree, pr_number, logger):
     # 2. Stash workflow state files that are routinely dirty in agent worktrees.
     #    Only stash known-safe paths — if other files are dirty the rebase
     #    should fail so the user is aware of unexpected uncommitted changes.
-    _STASHABLE = (".claude/state/", ".workflow/")
+    _STASHABLE = (".claude/state/", ".workflow/", ".retros/")
     stashed = False
     try:
         status = _run(["git", "status", "--porcelain"])

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1202,15 +1202,18 @@ class TestRebaseBeforeReady:
         assert result is True
         # First call: gh pr view to detect base
         assert call_log[0][:3] == ["gh", "pr", "view"]
-        # Then fetch + rebase + rev-parse + push with explicit refspec
+        # Then fetch-base + status (stash check) + rebase + rev-parse
+        # + fetch-source (tracking ref update) + push
         assert call_log[1] == ["git", "fetch", "origin", "--", "main"]
-        assert call_log[2] == ["git", "rebase", "--", "origin/main"]
-        assert call_log[3] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
-        assert call_log[4] == [
+        assert call_log[2] == ["git", "status", "--porcelain"]
+        assert call_log[3] == ["git", "rebase", "--", "origin/main"]
+        assert call_log[4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        assert call_log[5] == ["git", "fetch", "origin", "--", "feature-branch"]
+        assert call_log[6] == [
             "git", "push", "--force-with-lease",
             "origin", "HEAD:feature-branch",
         ]
-        assert len(call_log) == 5  # no abort path
+        assert len(call_log) == 7  # no abort path
 
     def test_rebase_conflict_aborts_and_returns_false(self, tmp_path):
         """On rebase conflict: git rebase --abort is called; no push; returns False."""
@@ -1307,6 +1310,75 @@ class TestRebaseBeforeReady:
         # Must NOT have used main
         assert not any(
             c == ["git", "fetch", "origin", "--", "main"] for c in call_log)
+
+
+class TestStaleTrackingRef:
+    """Regression #929: fetch feature branch before push to avoid stale tracking ref.
+
+    After the triage agent pushes to the remote, the local tracking ref is
+    stale.  --force-with-lease compares the stale ref against the actual
+    remote and rejects the push.  The fix fetches the feature branch before
+    pushing.
+    """
+
+    def test_fetch_source_runs_before_push(self, tmp_path):
+        """The feature branch must be fetched between rev-parse and push."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="feat/my-branch\n", stderr="")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is True
+        fetch_src = ["git", "fetch", "origin", "--", "feat/my-branch"]
+        assert fetch_src in call_log
+        fetch_idx = call_log.index(fetch_src)
+        push_idx = next(
+            i for i, c in enumerate(call_log) if c[:2] == ["git", "push"])
+        rev_parse_idx = next(
+            i for i, c in enumerate(call_log)
+            if c[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        assert rev_parse_idx < fetch_idx < push_idx
+
+    def test_fetch_source_failure_returns_false_and_does_not_push(self, tmp_path):
+        """If fetching the feature branch fails, no push and return False."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="feat/stale\n", stderr="")
+            # Fail the source-branch fetch (but not the base-branch fetch)
+            if cmd == ["git", "fetch", "origin", "--", "feat/stale"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=128, stdout="",
+                    stderr="fatal: couldn't find remote ref feat/stale")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is False
+        assert not any(c[:2] == ["git", "push"] for c in call_log)
 
 
 class TestDetectBaseBranch:

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1381,6 +1381,79 @@ class TestStaleTrackingRef:
         assert not any(c[:2] == ["git", "push"] for c in call_log)
 
 
+class TestUntrackedFilesDoNotBlockStash:
+    """Regression #929: untracked files should not poison the stash safety check.
+
+    git status --porcelain emits ?? for untracked files.  These don't block
+    rebase, but if included in the dirty list they prevent stashing of
+    legitimately dirty (modified) files that DO block rebase.
+    """
+
+    def test_untracked_file_excluded_from_stash_safety_check(self, tmp_path):
+        """Modified .claude/state/ file is stashed even when an untracked .retros/ file exists."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="feat/test\n", stderr="")
+            if cmd == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout=" M .claude/state/in-flight-issues.json\n"
+                           "?? .retros/summary.md\n",
+                    stderr="")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is True
+        stash_calls = [c for c in call_log if c[:2] == ["git", "stash"]]
+        assert len(stash_calls) >= 1
+        push_call = stash_calls[0]
+        assert push_call[:4] == ["git", "stash", "push", "-m"]
+        assert ".claude/state/in-flight-issues.json" in push_call
+        assert ".retros/summary.md" not in push_call
+
+    def test_only_untracked_files_skips_stash_entirely(self, tmp_path):
+        """When all dirty entries are untracked, no stash is needed."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="feat/test\n", stderr="")
+            if cmd == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout="?? .retros/summary.md\n"
+                           "?? some-other-untracked.txt\n",
+                    stderr="")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is True
+        stash_calls = [c for c in call_log if c[:2] == ["git", "stash"]]
+        assert len(stash_calls) == 0
+
+
 class TestDetectBaseBranch:
     """Regression: gh pr view argv must not include ``--`` before the PR number.
 

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1174,6 +1174,43 @@ class TestReplyDedupe:
             assert (42, 999) in pr_monitor._POSTED_REPLY_KEYS
 
 
+class TestStepCompletedResumeLogic:
+    """Regression #929: failed steps must be retried on --resume.
+
+    step_completed() previously returned True for any recorded status,
+    including failures like 'rebase_failed' and 'error'. On resume,
+    this caused failed steps to be skipped instead of retried.
+    """
+
+    def test_done_is_completed(self):
+        result = {"steps_completed": {"ready": {"status": "done", "timestamp": "t"}}}
+        assert pr_monitor.step_completed(result, "ready") is True
+
+    def test_pass_is_completed(self):
+        result = {"steps_completed": {"ci": {"status": "pass", "timestamp": "t"}}}
+        assert pr_monitor.step_completed(result, "ci") is True
+
+    def test_rebase_failed_is_not_completed(self):
+        result = {"steps_completed": {"ready": {"status": "rebase_failed", "timestamp": "t"}}}
+        assert pr_monitor.step_completed(result, "ready") is False
+
+    def test_skipped_is_not_completed(self):
+        result = {"steps_completed": {"ready": {"status": "skipped", "timestamp": "t"}}}
+        assert pr_monitor.step_completed(result, "ready") is False
+
+    def test_error_is_not_completed(self):
+        result = {"steps_completed": {"retro": {"status": "error", "timestamp": "t"}}}
+        assert pr_monitor.step_completed(result, "retro") is False
+
+    def test_missing_step_is_not_completed(self):
+        result = {"steps_completed": {}}
+        assert pr_monitor.step_completed(result, "ready") is False
+
+    def test_no_steps_completed_key(self):
+        result = {}
+        assert pr_monitor.step_completed(result, "ready") is False
+
+
 class TestRebaseBeforeReady:
     """Meta-retro finding #6: rebase source branch before flipping ready."""
 

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1490,6 +1490,36 @@ class TestUntrackedFilesDoNotBlockStash:
         stash_calls = [c for c in call_log if c[:2] == ["git", "stash"]]
         assert len(stash_calls) == 0
 
+    def test_retros_dir_is_stashable(self, tmp_path):
+        """Modified .retros/ files are safe to stash (written by monitor retro step)."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="feat/test\n", stderr="")
+            if cmd == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout=" M .retros/summary.json\n",
+                    stderr="")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is True
+        stash_calls = [c for c in call_log if c[:2] == ["git", "stash"]]
+        assert len(stash_calls) >= 1
+        assert ".retros/summary.json" in stash_calls[0]
+
 
 class TestDetectBaseBranch:
     """Regression: gh pr view argv must not include ``--`` before the PR number.


### PR DESCRIPTION
## Summary
Three bugs in `_rebase_source_branch()` and the monitor resume logic, all causing PR to stay in draft:

- **Stale tracking ref:** After the triage agent pushes fixes to the remote feature branch, `--force-with-lease` compares the stale local tracking ref against the updated remote and rejects the push. Fix: fetch `origin/<feature-branch>` between branch detection and push.
- **Untracked files poison stash check:** `git status --porcelain` `??` (untracked) lines were included in the dirty list, preventing legitimate modified files from being stashed and causing rebase to fail. Fix: filter out `??` lines before evaluating stashability.
- **Resume skips failed steps:** `step_completed()` returned `True` for any recorded status including `rebase_failed` and `error`, so `--resume` skipped failed steps instead of retrying them. Fix: only `done` and `pass` count as completed.

Also fixes the existing `test_rebase_clean_path` test which was out of sync with the stash-check call sequence.

Closes #929

## Test Plan
- [x] `test_fetch_source_runs_before_push` — verifies fetch ordering: rev-parse < fetch-source < push
- [x] `test_fetch_source_failure_returns_false_and_does_not_push` — verifies error path
- [x] `test_untracked_file_excluded_from_stash_safety_check` — modified .claude/state/ stashed even with untracked .retros/ present
- [x] `test_only_untracked_files_skips_stash_entirely` — all-untracked status skips stash
- [x] `test_done_is_completed` / `test_pass_is_completed` — success statuses skip on resume
- [x] `test_rebase_failed_is_not_completed` / `test_skipped_is_not_completed` / `test_error_is_not_completed` — failure statuses retry on resume
- [x] Updated `test_rebase_clean_path_calls_all_three_git_commands` — full 7-step call sequence
- [x] All 74 pr_monitor tests pass
- [x] Full .NET test suite (16,072 tests) passes

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: workflow)
- [x] Self-review: zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)