### PR TITLE
fix(pipeline): treat child processes as heartbeat liveness signal

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -281,7 +281,7 @@ def get_child_process_count(pid):
             )
             if result.returncode == 0:
                 lines = [l.strip() for l in result.stdout.strip().splitlines()
-                         if l.strip() and l.strip() != "ProcessId"]
+                         if l.strip().isdigit()]
                 return len(lines)
         else:
             result = subprocess.run(

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -269,8 +269,36 @@ def release_lock(lock_path):
         pass
 
 
+def get_child_process_count(pid):
+    """Count active child processes of a given PID."""
+    try:
+        if sys.platform == "win32":
+            result = subprocess.run(
+                ["wmic", "process", "where", f"ParentProcessId={pid}",
+                 "get", "ProcessId"],
+                capture_output=True, text=True, timeout=5,
+                encoding="utf-8", errors="replace",
+            )
+            if result.returncode == 0:
+                lines = [l.strip() for l in result.stdout.strip().splitlines()
+                         if l.strip() and l.strip() != "ProcessId"]
+                return len(lines)
+        else:
+            result = subprocess.run(
+                ["pgrep", "-P", str(pid)],
+                capture_output=True, text=True, timeout=5,
+                encoding="utf-8", errors="replace",
+            )
+            if result.returncode == 0:
+                return len(result.stdout.strip().splitlines())
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError, OSError):
+        pass
+    return 0
+
+
 def classify_activity(current_size, last_size, git_changes, last_git_changes,
-                      commits, last_commits, consecutive_idle):
+                      commits, last_commits, consecutive_idle, *,
+                      has_children=False):
     """Classify heartbeat activity based on multi-signal detection.
 
     Returns (activity_string, updated_consecutive_idle).
@@ -279,7 +307,7 @@ def classify_activity(current_size, last_size, git_changes, last_git_changes,
     git_grew = git_changes > last_git_changes
     commits_grew = commits > last_commits
 
-    if output_grew or git_grew or commits_grew:
+    if output_grew or git_grew or commits_grew or has_children:
         return "active", 0
     else:
         consecutive_idle += 1
@@ -452,12 +480,14 @@ def run_claude(worktree_path, prompt, logger, stage, dry_run=False,
                     current_size = 0
 
                 git_changes, commits = get_git_activity(worktree_path)
+                child_count = get_child_process_count(proc.pid)
 
                 activity, consecutive_idle = classify_activity(
                     current_size, last_log_size,
                     git_changes, last_git_changes,
                     commits, last_commits,
                     consecutive_idle,
+                    has_children=child_count > 0,
                 )
 
                 last_log_size = current_size
@@ -467,7 +497,8 @@ def run_claude(worktree_path, prompt, logger, stage, dry_run=False,
                 log(logger, stage, "HEARTBEAT",
                     elapsed=f"{int(elapsed)}s", pid=proc.pid,
                     output_bytes=current_size, git_changes=git_changes,
-                    commits=commits, activity=activity)
+                    commits=commits, children=child_count,
+                    activity=activity)
                 last_heartbeat = time.time()
 
                 # Stall timeout — kill after STALL_LIMIT consecutive idle heartbeats

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -558,6 +558,19 @@ class TestChildProcessDetection:
                                  side_effect=subprocess.TimeoutExpired("cmd", 5)):
             assert pipeline.get_child_process_count(100) == 0
 
+    def test_wmic_no_instances_returns_zero(self):
+        """AC-147: wmic 'No Instance(s) Available.' is not counted as a child."""
+        import pipeline
+
+        with unittest.mock.patch("pipeline.subprocess.run") as mock_run, \
+             unittest.mock.patch("pipeline.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            mock_run.return_value = unittest.mock.Mock(
+                returncode=0,
+                stdout="No Instance(s) Available.\n",
+            )
+            assert pipeline.get_child_process_count(100) == 0
+
 
 # ---------------------------------------------------------------------------
 # AC-70: JSONL post-processing

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -420,7 +420,7 @@ class TestStreamJsonOutput:
 # ---------------------------------------------------------------------------
 class TestHeartbeatMultiSignal:
     def test_heartbeat_multi_signal(self):
-        """AC-68: Heartbeat log contains git_changes and commits fields."""
+        """AC-68: Heartbeat log contains git_changes, commits, and children fields."""
         import pipeline
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -429,7 +429,7 @@ class TestHeartbeatMultiSignal:
             pipeline.log(
                 logger, "test", "HEARTBEAT",
                 elapsed="60s", pid=12345, output_bytes=1024,
-                git_changes=5, commits=3, activity="active",
+                git_changes=5, commits=3, children=2, activity="active",
             )
             logger.close()
 
@@ -439,6 +439,7 @@ class TestHeartbeatMultiSignal:
             assert "git_changes=5" in content
             assert "commits=3" in content
             assert "output_bytes=1024" in content
+            assert "children=2" in content
             assert "activity=active" in content
 
 
@@ -480,6 +481,82 @@ class TestActivityClassification:
         activity, idle = pipeline.classify_activity(100, 100, 3, 3, 2, 2, 2)
         assert activity == "stalled"
         assert idle == 3
+
+    def test_active_when_has_children(self):
+        """AC-147: Child processes count as liveness signal (#917)."""
+        import pipeline
+        activity, idle = pipeline.classify_activity(
+            100, 100, 3, 3, 2, 2, 4, has_children=True,
+        )
+        assert activity == "active"
+        assert idle == 0
+
+    def test_idle_when_no_children(self):
+        """AC-147: No children + no other activity = idle (default behavior)."""
+        import pipeline
+        activity, idle = pipeline.classify_activity(
+            100, 100, 3, 3, 2, 2, 1, has_children=False,
+        )
+        assert activity == "idle"
+        assert idle == 2
+
+    def test_children_prevent_stall_timeout(self):
+        """AC-147: Child processes prevent stall accumulation across beats."""
+        import pipeline
+        consecutive_idle = 0
+        for _ in range(pipeline.STALL_LIMIT + 2):
+            activity, consecutive_idle = pipeline.classify_activity(
+                100, 100, 3, 3, 2, 2, consecutive_idle, has_children=True,
+            )
+        assert consecutive_idle == 0
+        assert activity == "active"
+
+
+# ---------------------------------------------------------------------------
+# AC-147: Child process detection
+# ---------------------------------------------------------------------------
+class TestChildProcessDetection:
+    def test_returns_zero_when_no_children(self):
+        """AC-147: get_child_process_count returns 0 when subprocess finds none."""
+        import pipeline
+
+        with unittest.mock.patch("pipeline.subprocess.run") as mock_run:
+            mock_run.return_value = unittest.mock.Mock(
+                returncode=1, stdout="", stderr="",
+            )
+            assert pipeline.get_child_process_count(99999) == 0
+
+    def test_returns_count_on_unix(self):
+        """AC-147: get_child_process_count parses pgrep output on non-Windows."""
+        import pipeline
+
+        with unittest.mock.patch("pipeline.subprocess.run") as mock_run, \
+             unittest.mock.patch("pipeline.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            mock_run.return_value = unittest.mock.Mock(
+                returncode=0, stdout="1234\n5678\n",
+            )
+            assert pipeline.get_child_process_count(100) == 2
+
+    def test_returns_count_on_windows(self):
+        """AC-147: get_child_process_count parses wmic output on Windows."""
+        import pipeline
+
+        with unittest.mock.patch("pipeline.subprocess.run") as mock_run, \
+             unittest.mock.patch("pipeline.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            mock_run.return_value = unittest.mock.Mock(
+                returncode=0, stdout="ProcessId  \n1234  \n5678  \n",
+            )
+            assert pipeline.get_child_process_count(100) == 2
+
+    def test_handles_timeout_gracefully(self):
+        """AC-147: get_child_process_count returns 0 on subprocess timeout."""
+        import pipeline
+
+        with unittest.mock.patch("pipeline.subprocess.run",
+                                 side_effect=subprocess.TimeoutExpired("cmd", 5)):
+            assert pipeline.get_child_process_count(100) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add child process detection as a 4th heartbeat liveness signal in `classify_activity()`, preventing the pipeline stall timeout from killing gates while `dotnet test` runs legitimately in background
- Add `get_child_process_count(pid)` helper with cross-platform support (wmic on Windows, pgrep on Unix) and safe fallback to 0 on any error
- Filter wmic output to numeric PIDs only, avoiding false positives from "No Instance(s) Available." text

Closes #917

## Test Plan
- [x] 8 new tests (AC-147): has_children active signal, idle without children, stall prevention across beats, child process detection on Unix/Windows, timeout handling, wmic no-instances edge case
- [x] All 17 existing stall/heartbeat/activity tests still pass (backward compatible via keyword-only `has_children=False` default)
- [x] Full gate suite green: .NET build + 13,256 tests, TS build + typecheck + lint + 438 tests, TUI snapshots

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)