### PR TITLE
feat(extension): standardize toolbar layout and search placement (#898, #899)

### DIFF
--- a/.claude/rules/extension.md
+++ b/.claude/rules/extension.md
@@ -21,6 +21,27 @@ paths: ["src/PPDS.Extension/**"]
 
 - Content wrapper uses `class="content"` (not `class="panel-content"`) — all panels follow this convention
 
+## Toolbar Layout Convention
+
+Standard button order (left to right):
+
+```
+Refresh | Panel Actions | Maker Portal | spacer | Search | Filters/Toggles | Sort | EnvPicker
+```
+
+- **Refresh** — always first
+- **Panel-specific actions** — next (e.g., Analyze, Sync, Delete, Export, Publish, New Table)
+- **Maker Portal** — last action button before the spacer
+- **`<span class="toolbar-spacer">`** — pushes everything after it to the right
+- **Search** — `<input class="toolbar-search">`, always first in the right group
+- **Filters/Toggles** — segmented controls, checkboxes (`class="toolbar-checkbox"`), solution filters
+- **Sort** — `<select class="toolbar-select">` when present
+- **EnvPicker** — always last (`${getEnvironmentPickerHtml()}`)
+
+Shared CSS classes (defined in `shared.css`, not in panel CSS):
+- `.toolbar-search` — search input styling
+- `.toolbar-checkbox` — label+checkbox toggle in toolbar
+
 ## Code Rules
 
 - External CSS only (no inline styles) — VS Code silently drops inline scripts exceeding ~32KB

--- a/.claude/rules/extension.md
+++ b/.claude/rules/extension.md
@@ -38,6 +38,8 @@ Refresh | Panel Actions | Maker Portal | spacer | Search | Filters/Toggles | Sor
 - **Sort** — `<select class="toolbar-select">` when present
 - **EnvPicker** — always last (`${getEnvironmentPickerHtml()}`)
 
+Tool-type panels (e.g., Data Explorer) may substitute their primary action for Refresh and omit Search.
+
 Shared CSS classes (defined in `shared.css`, not in panel CSS):
 - `.toolbar-search` — search input styling
 - `.toolbar-checkbox` — label+checkbox toggle in toolbar

--- a/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
+++ b/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
@@ -397,13 +397,13 @@ export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionRefere
     <vscode-button id="analyze-btn" appearance="secondary" title="Analyze orphaned references">Analyze</vscode-button>
     <vscode-button id="sync-btn" appearance="secondary" title="Sync deployment settings for connection references">Sync Deployment Settings</vscode-button>
     <vscode-button id="maker-btn" appearance="secondary" title="Open Connections in Maker Portal">Maker Portal</vscode-button>
+    <span class="toolbar-spacer"></span>
+    <input id="search-input" type="text" placeholder="Search connection references..." class="toolbar-search" />
     <div id="solution-filter-container" class="solution-filter-container"></div>
     <div class="toolbar-segmented" id="inactive-toggle" title="Active = enabled in Dataverse (statecode 0). 'All' includes deactivated references.">
         <button class="seg-btn seg-active" id="seg-active" data-value="active" title="Show only enabled connection references">Active Only</button>
         <button class="seg-btn" id="seg-all" data-value="all" title="Include deactivated connection references">All</button>
     </div>
-    <input id="search-input" type="text" placeholder="Search connection references..." class="toolbar-search" />
-    <span class="toolbar-spacer"></span>
     ${getEnvironmentPickerHtml()}
 </div>
 

--- a/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
+++ b/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
@@ -398,12 +398,12 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
     <vscode-button id="export-btn" appearance="secondary" title="Export deployment settings">Export</vscode-button>
     <vscode-button id="sync-btn" appearance="secondary" title="Sync deployment settings">Sync Settings</vscode-button>
     <vscode-button id="maker-btn" appearance="secondary" title="Open Environment Variables in Maker Portal">Maker Portal</vscode-button>
+    <span class="toolbar-spacer"></span>
+    <input id="search-input" type="text" placeholder="Search variables..." class="toolbar-search" />
     <div id="solution-filter-container" class="solution-filter-container"></div>
     <div class="toolbar-toggle" id="inactive-toggle" title="Active = enabled in Dataverse (statecode 0). Toggle to include deactivated variables.">
         <span id="inactive-toggle-label">Active Only</span>
     </div>
-    <input id="search-input" type="text" placeholder="Search variables..." class="toolbar-search" />
-    <span class="toolbar-spacer"></span>
     ${getEnvironmentPickerHtml()}
 </div>
 

--- a/src/PPDS.Extension/src/panels/ImportJobsPanel.ts
+++ b/src/PPDS.Extension/src/panels/ImportJobsPanel.ts
@@ -216,8 +216,8 @@ export class ImportJobsPanel extends WebviewPanelBase<ImportJobsPanelWebviewToHo
 <div class="toolbar">
     <vscode-button id="refresh-btn" appearance="secondary" title="Refresh import jobs">Refresh</vscode-button>
     <vscode-button id="maker-btn" appearance="secondary" title="Open Solution History in Maker Portal">Maker Portal</vscode-button>
-    <input id="search-input" type="text" placeholder="Search import jobs..." title="Filter by solution name, status, created by" class="toolbar-search" />
     <span class="toolbar-spacer"></span>
+    <input id="search-input" type="text" placeholder="Search import jobs..." title="Filter by solution name, status, created by" class="toolbar-search" />
     ${getEnvironmentPickerHtml()}
 </div>
 

--- a/src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts
+++ b/src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts
@@ -382,29 +382,25 @@ export class MetadataBrowserPanel extends WebviewPanelBase<MetadataBrowserPanelW
 
 <div class="toolbar">
     <vscode-button id="refresh-btn" appearance="secondary" title="Refresh entity list">Refresh</vscode-button>
-    <vscode-button id="maker-btn" appearance="secondary" title="Open in Maker Portal">Maker Portal</vscode-button>
     <vscode-button id="new-table-btn" appearance="secondary" title="Create a new table">New Table</vscode-button>
     <vscode-button id="new-column-btn" appearance="secondary" title="Create a new column on the selected table">New Column</vscode-button>
+    <vscode-button id="maker-btn" appearance="secondary" title="Open in Maker Portal">Maker Portal</vscode-button>
     <span class="toolbar-spacer"></span>
+    <input type="text" id="entity-search" class="toolbar-search" placeholder="Search entities and choices..." />
+    <span id="filter-count"></span>
+    <label class="toolbar-checkbox" title="Show only custom entities">
+        <input type="checkbox" id="hide-system-toggle" />
+        <span>Custom Only</span>
+    </label>
+    <label class="toolbar-checkbox" title="Include many-to-many intersect entities">
+        <input type="checkbox" id="include-intersect-toggle" />
+        <span>Include Intersect</span>
+    </label>
     ${getEnvironmentPickerHtml()}
 </div>
 
 <div class="split-pane">
     <div class="entity-list-pane" id="entity-list-pane">
-        <div class="search-container">
-            <input type="text" id="entity-search" placeholder="Search entities and choices..." />
-            <span id="filter-count"></span>
-        </div>
-        <div class="filter-toggle-container">
-            <label class="filter-toggle-label">
-                <input type="checkbox" id="hide-system-toggle" />
-                <span>Custom Only</span>
-            </label>
-            <label class="filter-toggle-label">
-                <input type="checkbox" id="include-intersect-toggle" />
-                <span>Include Intersect</span>
-            </label>
-        </div>
         <div class="entity-list" id="entity-list"></div>
     </div>
     <div class="entity-detail-pane" id="entity-detail-pane">

--- a/src/PPDS.Extension/src/panels/PluginsPanel.ts
+++ b/src/PPDS.Extension/src/panels/PluginsPanel.ts
@@ -576,19 +576,19 @@ export class PluginsPanel extends WebviewPanelBase<PluginsPanelWebviewToHost, Pl
 
 <div class="toolbar">
     <vscode-button id="refresh-btn" appearance="secondary" title="Refresh plugin registrations">Refresh</vscode-button>
+    <vscode-button id="expand-all-btn" appearance="secondary" title="Expand all nodes">Expand All</vscode-button>
+    <vscode-button id="collapse-all-btn" appearance="secondary" title="Collapse all nodes">Collapse All</vscode-button>
+    <span class="toolbar-spacer"></span>
+    <input type="text" id="search-input" class="toolbar-search" placeholder="Search registrations..." title="Filter by name, message, or entity" />
     <div class="view-mode-group">
         <vscode-button id="view-mode-assembly" class="view-mode-btn active" appearance="secondary" title="View by assembly">Assembly</vscode-button>
         <vscode-button id="view-mode-message" class="view-mode-btn" appearance="secondary" title="View by message">Message</vscode-button>
         <vscode-button id="view-mode-entity" class="view-mode-btn" appearance="secondary" title="View by entity">Entity</vscode-button>
     </div>
-    <vscode-button id="expand-all-btn" appearance="secondary" title="Expand all nodes">Expand All</vscode-button>
-    <vscode-button id="collapse-all-btn" appearance="secondary" title="Collapse all nodes">Collapse All</vscode-button>
-    <span class="toolbar-spacer"></span>
-    <input type="text" id="search-input" class="toolbar-search" placeholder="Search registrations..." title="Filter by name, message, or entity" />
-    <label class="filter-checkbox" title="Hide disabled steps">
+    <label class="toolbar-checkbox" title="Hide disabled steps">
         <input type="checkbox" id="hide-hidden-check" /> Hide Disabled
     </label>
-    <label class="filter-checkbox" title="Hide Microsoft-managed assemblies">
+    <label class="toolbar-checkbox" title="Hide Microsoft-managed assemblies">
         <input type="checkbox" id="hide-microsoft-check" /> Hide Microsoft
     </label>
     ${getEnvironmentPickerHtml()}

--- a/src/PPDS.Extension/src/panels/PluginsPanel.ts
+++ b/src/PPDS.Extension/src/panels/PluginsPanel.ts
@@ -586,10 +586,10 @@ export class PluginsPanel extends WebviewPanelBase<PluginsPanelWebviewToHost, Pl
         <vscode-button id="view-mode-entity" class="view-mode-btn" appearance="secondary" title="View by entity">Entity</vscode-button>
     </div>
     <label class="toolbar-checkbox" title="Hide disabled steps">
-        <input type="checkbox" id="hide-hidden-check" /> Hide Disabled
+        <input type="checkbox" id="hide-hidden-check" /> <span>Hide Disabled</span>
     </label>
     <label class="toolbar-checkbox" title="Hide Microsoft-managed assemblies">
-        <input type="checkbox" id="hide-microsoft-check" /> Hide Microsoft
+        <input type="checkbox" id="hide-microsoft-check" /> <span>Hide Microsoft</span>
     </label>
     ${getEnvironmentPickerHtml()}
 </div>

--- a/src/PPDS.Extension/src/panels/SolutionsPanel.ts
+++ b/src/PPDS.Extension/src/panels/SolutionsPanel.ts
@@ -233,6 +233,7 @@ export class SolutionsPanel extends WebviewPanelBase<SolutionsPanelWebviewToHost
 <div class="toolbar">
     <vscode-button id="refresh-btn" appearance="secondary" title="Refresh solutions">Refresh</vscode-button>
     <vscode-button id="maker-portal-btn" appearance="secondary" title="Open in Maker Portal">Maker Portal</vscode-button>
+    <span class="toolbar-spacer"></span>
     <input id="search-input" type="text" placeholder="Search solutions..." class="toolbar-search" />
     <div class="segmented-control" id="visibility-filter" title="Show visible solutions only, or all including internal">
         <button class="seg-btn active" data-value="visible">Visible</button>
@@ -248,7 +249,6 @@ export class SolutionsPanel extends WebviewPanelBase<SolutionsPanelWebviewToHost
         <option value="publisher">Sort: Publisher</option>
         <option value="modifiedOn">Sort: Modified</option>
     </select>
-    <span class="toolbar-spacer"></span>
     ${getEnvironmentPickerHtml()}
 </div>
 

--- a/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
+++ b/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
@@ -449,7 +449,7 @@ export class WebResourcesPanel extends WebviewPanelBase<WebResourcesPanelWebview
         <span class="solution-filter-label">Solution:</span>
         <div id="solution-filter-container"></div>
     </div>
-    <label class="text-only-toggle" title="Show only text-based web resources (JS, CSS, HTML, XML)">
+    <label class="toolbar-checkbox" title="Show only text-based web resources (JS, CSS, HTML, XML)">
         <input type="checkbox" id="text-only-cb" checked>
         Text only
     </label>

--- a/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
+++ b/src/PPDS.Extension/src/panels/WebResourcesPanel.ts
@@ -443,6 +443,8 @@ export class WebResourcesPanel extends WebviewPanelBase<WebResourcesPanelWebview
     <vscode-button id="publish-btn" appearance="secondary" title="Publish selected web resources" disabled>Publish</vscode-button>
     <vscode-button id="publish-all-btn" appearance="secondary" title="Publish all customizations">Publish All</vscode-button>
     <vscode-button id="maker-btn" appearance="secondary" title="Open Web Resources in Maker Portal">Maker Portal</vscode-button>
+    <span class="toolbar-spacer"></span>
+    <input type="text" id="wr-search" class="toolbar-search" placeholder="Search web resources..." title="Filter by name" />
     <div class="solution-filter">
         <span class="solution-filter-label">Solution:</span>
         <div id="solution-filter-container"></div>
@@ -451,8 +453,6 @@ export class WebResourcesPanel extends WebviewPanelBase<WebResourcesPanelWebview
         <input type="checkbox" id="text-only-cb" checked>
         Text only
     </label>
-    <input type="text" id="wr-search" class="toolbar-search" placeholder="Search web resources..." title="Filter by name" />
-    <span class="toolbar-spacer"></span>
     ${getEnvironmentPickerHtml()}
 </div>
 

--- a/src/PPDS.Extension/src/panels/styles/connection-references-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/connection-references-panel.css
@@ -348,29 +348,6 @@
     padding: 8px 0;
 }
 
-/* ── Toolbar Search ──────────────────────────────────────────── */
-.toolbar-search {
-    flex: 1;
-    min-width: 120px;
-    max-width: 300px;
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border, transparent);
-    padding: 3px 8px;
-    border-radius: 2px;
-    font-size: 12px;
-    font-family: var(--vscode-font-family);
-    outline: none;
-}
-
-.toolbar-search:focus {
-    outline: 1px solid var(--vscode-focusBorder);
-}
-
-.toolbar-search::placeholder {
-    color: var(--vscode-input-placeholderForeground);
-}
-
 /* ── Active/All segmented toggle (V-16) ──────────────────────── */
 .toolbar-segmented {
     display: flex;

--- a/src/PPDS.Extension/src/panels/styles/environment-variables-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/environment-variables-panel.css
@@ -297,25 +297,3 @@
     color: var(--vscode-button-foreground, var(--vscode-foreground));
 }
 
-/* ── Toolbar Search ──────────────────────────────────────────── */
-.toolbar-search {
-    flex: 1;
-    min-width: 120px;
-    max-width: 300px;
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border, transparent);
-    padding: 3px 8px;
-    border-radius: 2px;
-    font-size: 12px;
-    font-family: var(--vscode-font-family);
-    outline: none;
-}
-
-.toolbar-search:focus {
-    outline: 1px solid var(--vscode-focusBorder);
-}
-
-.toolbar-search::placeholder {
-    color: var(--vscode-input-placeholderForeground);
-}

--- a/src/PPDS.Extension/src/panels/styles/import-jobs-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/import-jobs-panel.css
@@ -119,25 +119,3 @@ a.solution-link:hover {
     color: var(--vscode-editorWarning-foreground, #cca700);
 }
 
-/* ── Toolbar Search ──────────────────────────────────────────── */
-.toolbar-search {
-    flex: 1;
-    min-width: 120px;
-    max-width: 300px;
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border, transparent);
-    padding: 3px 8px;
-    border-radius: 2px;
-    font-size: 12px;
-    font-family: var(--vscode-font-family);
-    outline: none;
-}
-
-.toolbar-search:focus {
-    outline: 1px solid var(--vscode-focusBorder);
-}
-
-.toolbar-search::placeholder {
-    color: var(--vscode-input-placeholderForeground);
-}

--- a/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
@@ -23,56 +23,10 @@
     overflow: hidden;
 }
 
-.search-container {
-    padding: 6px;
-    display: flex;
-    gap: 4px;
-    align-items: center;
-}
-
-#entity-search {
-    flex: 1;
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border);
-    padding: 4px 8px;
-    font-size: 13px;
-}
-
-#entity-search:focus {
-    outline: 1px solid var(--vscode-focusBorder);
-    outline-offset: -1px;
-}
-
 #filter-count {
     font-size: 11px;
     color: var(--vscode-descriptionForeground);
     white-space: nowrap;
-}
-
-/* ── Filter toggle ─────────────────────────────────────────────────────── */
-
-.filter-toggle-container {
-    padding: 2px 6px 4px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.filter-toggle-label {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 12px;
-    color: var(--vscode-descriptionForeground);
-    cursor: pointer;
-    user-select: none;
-}
-
-.filter-toggle-label input[type="checkbox"] {
-    accent-color: var(--vscode-focusBorder);
-    cursor: pointer;
-    margin: 0;
 }
 
 /* ── Section headers ───────────────────────────────────────────────────── */

--- a/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
@@ -918,26 +918,6 @@
     opacity: 1;
 }
 
-/* ── Toolbar search ────────────────────────────────────────────── */
-.toolbar-search {
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border, transparent);
-    padding: 3px 8px;
-    font-size: 12px;
-    font-family: var(--vscode-font-family);
-    min-width: 160px;
-    max-width: 240px;
-}
-
-.toolbar-search:focus {
-    outline: 1px solid var(--vscode-focusBorder);
-}
-
-.toolbar-search::placeholder {
-    color: var(--vscode-input-placeholderForeground);
-}
-
 /* ── Export Dropdown ───────────────────────────────────────────── */
 .export-dropdown {
     position: absolute;

--- a/src/PPDS.Extension/src/panels/styles/plugins-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/plugins-panel.css
@@ -21,27 +21,7 @@
     font-family: var(--vscode-font-family);
 }
 
-/* ── Search Input ────────────────────────────────────────────────── */
-#search-input {
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border, transparent);
-    padding: 4px 8px;
-    border-radius: 2px;
-    outline: none;
-    font-family: var(--vscode-font-family);
-    font-size: 12px;
-}
-
-#search-input:focus {
-    border-color: var(--vscode-focusBorder);
-}
-
-#search-input::placeholder {
-    color: var(--vscode-input-placeholderForeground);
-}
-
-/* ── Filter Bar ─────────────────────────────────────────────────── */
+/* ── Filter Bar ──────────────────────────────────��──────────────── */
 #filter-bar {
     display: flex;
     flex-flow: row wrap;
@@ -196,6 +176,12 @@
     color: var(--vscode-descriptionForeground);
     opacity: 0.7;
     white-space: nowrap;
+}
+
+.view-mode-group {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
 }
 
 /* ── View Mode Active State ──────────────────────────────────────── */

--- a/src/PPDS.Extension/src/panels/styles/shared.css
+++ b/src/PPDS.Extension/src/panels/styles/shared.css
@@ -57,6 +57,48 @@ input, textarea, pre, code, .selectable, [contenteditable], .data-table td {
     flex: 1;
 }
 
+/* ── Toolbar search input ────────────────────────────────────────────────── */
+
+.toolbar-search {
+    flex: 1;
+    min-width: 120px;
+    max-width: 300px;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    padding: 3px 8px;
+    border-radius: 2px;
+    font-size: 12px;
+    font-family: var(--vscode-font-family);
+    outline: none;
+}
+
+.toolbar-search:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+}
+
+.toolbar-search::placeholder {
+    color: var(--vscode-input-placeholderForeground);
+}
+
+/* ── Toolbar checkbox ────────────────────────────────────────────────── */
+
+.toolbar-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--vscode-foreground);
+    cursor: pointer;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.toolbar-checkbox input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+
 .status-bar {
     display: flex;
     gap: 16px;

--- a/src/PPDS.Extension/src/panels/styles/solutions-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/solutions-panel.css
@@ -2,22 +2,6 @@
 
 /* ── Solutions Panel specific styles ──────────────────────────────────────── */
 
-.toolbar-checkbox {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 12px;
-    color: var(--vscode-foreground);
-    cursor: pointer;
-    white-space: nowrap;
-    user-select: none;
-}
-
-.toolbar-checkbox input[type="checkbox"] {
-    margin: 0;
-    cursor: pointer;
-}
-
 .content {
     flex: 1;
     overflow: auto;
@@ -324,29 +308,6 @@
     background: var(--vscode-button-secondaryBackground, var(--vscode-list-activeSelectionBackground));
     color: var(--vscode-button-secondaryForeground, var(--vscode-list-activeSelectionForeground));
     font-weight: 500;
-}
-
-/* ── Toolbar Search ──────────────────────────────────────────── */
-.toolbar-search {
-    flex: 1;
-    min-width: 120px;
-    max-width: 300px;
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: 1px solid var(--vscode-input-border, transparent);
-    padding: 3px 8px;
-    border-radius: 2px;
-    font-size: 12px;
-    font-family: var(--vscode-font-family);
-    outline: none;
-}
-
-.toolbar-search:focus {
-    outline: 1px solid var(--vscode-focusBorder);
-}
-
-.toolbar-search::placeholder {
-    color: var(--vscode-input-placeholderForeground);
 }
 
 /* ── Toolbar Select ──────────────────────────────────────────── */

--- a/src/PPDS.Extension/src/panels/styles/web-resources-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/web-resources-panel.css
@@ -171,22 +171,6 @@
     outline: 1px solid var(--vscode-focusBorder);
 }
 
-/* ── Text-only toggle ──────────────────────────────────────────────────── */
-
-.text-only-toggle {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 11px;
-    color: var(--vscode-descriptionForeground);
-    white-space: nowrap;
-    cursor: pointer;
-}
-
-.text-only-toggle input[type="checkbox"] {
-    cursor: pointer;
-}
-
 /* ── Publish button ────────────────────────────────────────────────────── */
 
 .publish-btn[disabled] {


### PR DESCRIPTION
## Summary
- **Toolbar button order** (#899): Define and apply standard layout across all 8 panels with toolbars: `Refresh | Panel Actions | Maker Portal | spacer | Search | Filters/Toggles | Sort | EnvPicker`
- **Search/filter bar consistency** (#898): All panels now use `.toolbar-search` class inside the toolbar — Metadata Browser search moved from separate `.search-container` into the toolbar, eliminating the only outlier
- **CSS consolidation**: `.toolbar-search`, `.toolbar-checkbox` styles moved from 6+ panel-specific stylesheets into `shared.css`, removing ~140 lines of duplication
- **Convention documented**: Toolbar layout standard added to `.claude/rules/extension.md` for future panels

Closes #898
Closes #899

## Test Plan
- [x] Extension unit tests pass (438/438)
- [x] .NET build and tests pass (9,610/9,610)
- [x] TypeScript typecheck, lint, CSS lint pass
- [x] Visual verification: Solutions, MetadataBrowser, Plugins, WebResources, ConnectionReferences panels screenshotted and toolbar layout confirmed
- [x] No new console errors

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: extension)
- [x] Pre-PR self-review completed (0 defects, 2 suggestions addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)