### PR TITLE
fix(test): serialize env-var-mutating test classes to prevent race (#928)

### DIFF
--- a/tests/PPDS.Auth.Tests/Credentials/CredentialProviderFactoryTests.cs
+++ b/tests/PPDS.Auth.Tests/Credentials/CredentialProviderFactoryTests.cs
@@ -6,8 +6,22 @@ using Xunit;
 
 namespace PPDS.Auth.Tests.Credentials;
 
-public class CredentialProviderFactoryTests
+[Collection(EnvironmentVariableMutatingCollection.Name)]
+public sealed class CredentialProviderFactoryTests : IDisposable
 {
+    private readonly Dictionary<string, string?> _originalValues = new();
+
+    private void SetEnvVar(string name, string? value)
+    {
+        _originalValues.TryAdd(name, Environment.GetEnvironmentVariable(name));
+        Environment.SetEnvironmentVariable(name, value);
+    }
+
+    public void Dispose()
+    {
+        foreach (var (name, original) in _originalValues)
+            Environment.SetEnvironmentVariable(name, original);
+    }
     [Fact]
     public void Create_NullProfile_Throws()
     {
@@ -29,7 +43,6 @@ public class CredentialProviderFactoryTests
     [Fact]
     public void Create_ClientSecret_WithoutEnvVar_Throws()
     {
-        // ClientSecret requires either env var or secure store (CreateAsync)
         var profile = new AuthProfile
         {
             AuthMethod = AuthMethod.ClientSecret,
@@ -37,8 +50,8 @@ public class CredentialProviderFactoryTests
             TenantId = "tenant-id"
         };
 
-        // Clear the env var if set
-        Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
 
         var act = () => CredentialProviderFactory.Create(profile);
 
@@ -56,17 +69,11 @@ public class CredentialProviderFactoryTests
             TenantId = "tenant-id"
         };
 
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, "test-secret");
-            using var provider = CredentialProviderFactory.Create(profile);
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, "test-secret");
 
-            provider.Should().BeOfType<ClientSecretCredentialProvider>();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-        }
+        using var provider = CredentialProviderFactory.Create(profile);
+
+        provider.Should().BeOfType<ClientSecretCredentialProvider>();
     }
 
     [Fact]
@@ -199,74 +206,45 @@ public class CredentialProviderFactoryTests
     [Fact]
     public void GetSpnSecretFromEnvironment_WhenSpnSecretSet_ReturnsSpnSecret()
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, "spn-secret-value");
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, "spn-secret-value");
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
 
-            var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
+        var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
 
-            result.Should().Be("spn-secret-value");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-        }
+        result.Should().Be("spn-secret-value");
     }
 
     [Fact]
     public void GetSpnSecretFromEnvironment_WhenTestClientSecretSet_ReturnsTestClientSecret()
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, "test-secret-value");
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, "test-secret-value");
 
-            var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
+        var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
 
-            result.Should().Be("test-secret-value");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
-        }
+        result.Should().Be("test-secret-value");
     }
 
     [Fact]
     public void GetSpnSecretFromEnvironment_WhenBothSet_PrefersSspnSecret()
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, "spn-secret-value");
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, "test-secret-value");
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, "spn-secret-value");
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, "test-secret-value");
 
-            var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
+        var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
 
-            result.Should().Be("spn-secret-value", because: "PPDS_SPN_SECRET takes precedence over PPDS_TEST_CLIENT_SECRET");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
-        }
+        result.Should().Be("spn-secret-value", because: "PPDS_SPN_SECRET takes precedence over PPDS_TEST_CLIENT_SECRET");
     }
 
     [Fact]
     public void GetSpnSecretFromEnvironment_WhenNeitherSet_ReturnsNull()
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
 
-            var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
+        var result = CredentialProviderFactory.GetSpnSecretFromEnvironment();
 
-            result.Should().BeNull();
-        }
-        finally
-        {
-            // No cleanup needed
-        }
+        result.Should().BeNull();
     }
 
     #endregion
@@ -276,55 +254,34 @@ public class CredentialProviderFactoryTests
     [Fact]
     public void ShouldBypassCredentialStore_WhenSpnSecretSet_ReturnsTrue()
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, "any-value");
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, "any-value");
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
 
-            var result = CredentialProviderFactory.ShouldBypassCredentialStore();
+        var result = CredentialProviderFactory.ShouldBypassCredentialStore();
 
-            result.Should().BeTrue();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-        }
+        result.Should().BeTrue();
     }
 
     [Fact]
     public void ShouldBypassCredentialStore_WhenTestClientSecretSet_ReturnsTrue()
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, "any-value");
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, "any-value");
 
-            var result = CredentialProviderFactory.ShouldBypassCredentialStore();
+        var result = CredentialProviderFactory.ShouldBypassCredentialStore();
 
-            result.Should().BeTrue();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
-        }
+        result.Should().BeTrue();
     }
 
     [Fact]
     public void ShouldBypassCredentialStore_WhenNeitherSet_ReturnsFalse()
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
 
-            var result = CredentialProviderFactory.ShouldBypassCredentialStore();
+        var result = CredentialProviderFactory.ShouldBypassCredentialStore();
 
-            result.Should().BeFalse();
-        }
-        finally
-        {
-            // No cleanup needed
-        }
+        result.Should().BeFalse();
     }
 
     [Theory]
@@ -332,19 +289,12 @@ public class CredentialProviderFactoryTests
     [InlineData("   ")]
     public void ShouldBypassCredentialStore_WhenSetToEmptyOrWhitespace_ReturnsFalse(string value)
     {
-        try
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, value);
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.TestClientSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, value);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
 
-            var result = CredentialProviderFactory.ShouldBypassCredentialStore();
+        var result = CredentialProviderFactory.ShouldBypassCredentialStore();
 
-            result.Should().BeFalse(because: "empty or whitespace values should not trigger bypass");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar, null);
-        }
+        result.Should().BeFalse(because: "empty or whitespace values should not trigger bypass");
     }
 
     #endregion

--- a/tests/PPDS.Auth.Tests/EnvironmentVariableAuthTests.cs
+++ b/tests/PPDS.Auth.Tests/EnvironmentVariableAuthTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 namespace PPDS.Auth.Tests;
 
 [Trait("Category", "Unit")]
+[Collection(EnvironmentVariableMutatingCollection.Name)]
 public sealed class EnvironmentVariableAuthTests : IDisposable
 {
     private readonly Dictionary<string, string?> _originalValues = new();

--- a/tests/PPDS.Auth.Tests/EnvironmentVariableMutatingCollection.cs
+++ b/tests/PPDS.Auth.Tests/EnvironmentVariableMutatingCollection.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace PPDS.Auth.Tests;
+
+/// <summary>
+/// Serializes tests that mutate process-global environment variables
+/// (e.g. PPDS_SPN_SECRET, PPDS_TEST_CLIENT_SECRET).
+/// Without this, xUnit runs test classes in parallel and concurrent env var
+/// mutation causes intermittent failures — particularly on net8.0 where
+/// thread-pool scheduling surfaces the race more readily.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class EnvironmentVariableMutatingCollection
+{
+    public const string Name = nameof(EnvironmentVariableMutatingCollection);
+}


### PR DESCRIPTION
## Summary
- **Root cause:** `CredentialProviderFactoryTests` and `EnvironmentVariableAuthTests` both mutate process-level env vars (`PPDS_SPN_SECRET`, `PPDS_TEST_CLIENT_SECRET`). xUnit runs test classes in parallel, so concurrent mutation causes `ShouldBypassCredentialStore_WhenSpnSecretSet_ReturnsTrue` to fail intermittently on net8.0.
- **Fix:** Add `EnvironmentVariableMutatingCollection` (matching the existing `CurrentDirectoryMutatingCollection` pattern) to serialize these test classes. Also convert `CredentialProviderFactoryTests` to `IDisposable` with save/restore for robust env var cleanup.
- **Verified:** 469/469 auth tests pass on all 3 TFMs (net8.0/net9.0/net10.0); stress-tested with 16 parallel threads across 5 iterations — zero failures.

Closes #928

## Test Plan
- [x] Auth tests pass on net8.0, net9.0, net10.0
- [x] Full solution test suite passes (6,820+ tests)
- [x] Stress test: 5 consecutive runs with 16 parallel threads on net8.0 — 0 failures
- [x] Collection serialization verified: both classes tagged with `EnvironmentVariableMutatingCollection`

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: test infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)