### PR TITLE
feat(tui): add per-tab profile switching (#927)

### DIFF
--- a/src/PPDS.Cli/Tui/Dialogs/EnvironmentDetailsDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/EnvironmentDetailsDialog.cs
@@ -20,6 +20,7 @@ internal sealed class EnvironmentDetailsDialog : TuiDialog, ITuiStateCapture<Env
     private readonly string _environmentUrl;
     private readonly string? _environmentDisplayName;
     private readonly ITuiThemeService _themeService;
+    private readonly string? _profileName;
     private readonly CancellationTokenSource _cancellationSource = new();
     private bool _disposed;
 
@@ -43,12 +44,14 @@ internal sealed class EnvironmentDetailsDialog : TuiDialog, ITuiStateCapture<Env
     public EnvironmentDetailsDialog(
         InteractiveSession session,
         string environmentUrl,
-        string? environmentDisplayName = null) : base("View Organization Info", session)
+        string? environmentDisplayName = null,
+        string? profileName = null) : base("View Organization Info", session)
     {
         _session = session ?? throw new ArgumentNullException(nameof(session));
         _errorService = session.GetErrorService();
         _environmentUrl = environmentUrl ?? throw new ArgumentNullException(nameof(environmentUrl));
         _environmentDisplayName = environmentDisplayName;
+        _profileName = profileName;
         _themeService = session.GetThemeService();
 
         Width = Dim.Percent(80);
@@ -180,7 +183,7 @@ internal sealed class EnvironmentDetailsDialog : TuiDialog, ITuiStateCapture<Env
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var provider = await _session.GetServiceProviderAsync(_environmentUrl, cancellationToken);
+        var provider = await _session.GetServiceProviderAsync(_environmentUrl, _profileName, cancellationToken);
         var pool = provider.GetRequiredService<IDataverseConnectionPool>();
 
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/PPDS.Cli/Tui/Infrastructure/TabManager.cs
+++ b/src/PPDS.Cli/Tui/Infrastructure/TabManager.cs
@@ -37,16 +37,51 @@ internal sealed class TabManager : ITuiStateCapture<TabManagerState>, IDisposabl
     /// <summary>
     /// Adds a new tab and makes it active.
     /// </summary>
-    public void AddTab(ITuiScreen screen, string? environmentUrl, string? environmentDisplayName = null)
+    public void AddTab(
+        ITuiScreen screen,
+        string? environmentUrl,
+        string? environmentDisplayName = null,
+        string? profileName = null,
+        string? profileIdentity = null)
     {
         var envType = _themeService.DetectEnvironmentType(environmentUrl);
         var envColor = _themeService.GetResolvedColor(environmentUrl);
-        var tab = new TabInfo(screen, environmentUrl, environmentDisplayName, envType, envColor);
+        var tab = new TabInfo(screen, environmentUrl, environmentDisplayName, envType, envColor, profileName, profileIdentity);
         _tabs.Add(tab);
         _activeIndex = _tabs.Count - 1;
 
         TabsChanged?.Invoke();
         ActiveTabChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Updates the profile and environment of the tab at the given index.
+    /// Used when the user switches profile within a tab.
+    /// </summary>
+    public void UpdateTabProfile(
+        int index,
+        string? profileName,
+        string? profileIdentity,
+        string? environmentUrl,
+        string? environmentDisplayName)
+    {
+        if (index < 0 || index >= _tabs.Count) return;
+
+        var tab = _tabs[index];
+        var envType = _themeService.DetectEnvironmentType(environmentUrl);
+        var envColor = _themeService.GetResolvedColor(environmentUrl);
+        _tabs[index] = tab with
+        {
+            ProfileName = profileName,
+            ProfileIdentity = profileIdentity,
+            EnvironmentUrl = environmentUrl,
+            EnvironmentDisplayName = environmentDisplayName,
+            EnvironmentType = envType,
+            EnvironmentColor = envColor
+        };
+        TabsChanged?.Invoke();
+        if (index == _activeIndex)
+            ActiveTabChanged?.Invoke();
     }
 
     /// <summary>
@@ -154,7 +189,8 @@ internal sealed class TabManager : ITuiStateCapture<TabManagerState>, IDisposabl
             EnvironmentUrl: t.EnvironmentUrl,
             EnvironmentType: t.EnvironmentType,
             EnvironmentColor: t.EnvironmentColor,
-            IsActive: i == _activeIndex
+            IsActive: i == _activeIndex,
+            ProfileName: t.ProfileName
         )).ToList();
 
         return new TabManagerState(
@@ -183,4 +219,6 @@ internal sealed record TabInfo(
     string? EnvironmentUrl,
     string? EnvironmentDisplayName,
     EnvironmentType EnvironmentType,
-    EnvironmentColor EnvironmentColor);
+    EnvironmentColor EnvironmentColor,
+    string? ProfileName,
+    string? ProfileIdentity);

--- a/src/PPDS.Cli/Tui/InteractiveSession.cs
+++ b/src/PPDS.Cli/Tui/InteractiveSession.cs
@@ -48,6 +48,8 @@ internal sealed class InteractiveSession : IAsyncDisposable
     private readonly ConcurrentDictionary<string, ServiceProvider> _providers = new(StringComparer.OrdinalIgnoreCase);
     private string? _activeEnvironmentUrl;
     private string? _activeEnvironmentDisplayName;
+    private string? _displayedProfileName;
+    private string? _displayedProfileIdentity;
     private bool _disposed;
     private readonly EnvironmentConfigStore _envConfigStore;
     private readonly EnvironmentConfigService _envConfigService;
@@ -87,14 +89,22 @@ internal sealed class InteractiveSession : IAsyncDisposable
     public string? CurrentEnvironmentDisplayName => _activeEnvironmentDisplayName;
 
     /// <summary>
-    /// Gets the current profile name, or null if using the active profile.
+    /// Gets the currently displayed profile name (reflects the active tab's profile).
+    /// Falls back to the session default profile if no tab-specific override is set.
     /// </summary>
-    public string? CurrentProfileName => string.IsNullOrEmpty(_profileName) ? null : _profileName;
+    public string? CurrentProfileName =>
+        !string.IsNullOrEmpty(_displayedProfileName) ? _displayedProfileName :
+        !string.IsNullOrEmpty(_profileName) ? _profileName : null;
 
     /// <summary>
-    /// Gets the identity for the current profile (username or app ID), or null if unavailable.
+    /// Gets the session default profile name, used for creating new tabs.
     /// </summary>
-    public string? CurrentProfileIdentity { get; private set; }
+    public string? DefaultProfileName => string.IsNullOrEmpty(_profileName) ? null : _profileName;
+
+    /// <summary>
+    /// Gets the identity for the currently displayed profile (username or app ID), or null if unavailable.
+    /// </summary>
+    public string? CurrentProfileIdentity => _displayedProfileIdentity;
 
     /// <summary>
     /// Gets the environment configuration service for label, type, and color resolution.
@@ -170,7 +180,7 @@ internal sealed class InteractiveSession : IAsyncDisposable
         _profileResolutionService = new ProfileResolutionService(envConfigs.Environments);
 
         // Set the identity for status bar display
-        CurrentProfileIdentity = profile.IdentityDisplay;
+        _displayedProfileIdentity = profile.IdentityDisplay;
 
         // If using active profile (no explicit name specified), update _profileName
         // so CurrentProfileName returns the actual profile name instead of null
@@ -213,9 +223,28 @@ internal sealed class InteractiveSession : IAsyncDisposable
     }
 
     /// <summary>
+    /// Updates the displayed profile without changing the session default.
+    /// Use this when switching tabs to sync the status bar with the active tab's profile.
+    /// </summary>
+    /// <param name="profileName">The profile name to display.</param>
+    /// <param name="profileIdentity">The profile identity (username or app ID) to display.</param>
+    public void UpdateDisplayedProfile(string? profileName, string? profileIdentity)
+    {
+        if (_displayedProfileName == profileName && _displayedProfileIdentity == profileIdentity)
+            return;
+
+        _displayedProfileName = profileName;
+        _displayedProfileIdentity = profileIdentity;
+        ProfileChanged?.Invoke(profileName);
+    }
+
+    /// <summary>
     /// Notifies listeners that environment configuration has changed.
     /// </summary>
     public void NotifyConfigChanged() => ConfigChanged?.Invoke();
+
+    private static string ProviderKey(string profileName, string environmentUrl) =>
+        $"{profileName}\0{environmentUrl}";
 
     /// <summary>
     /// Switches to a new environment, updating the profile and warming the new connection.
@@ -251,22 +280,40 @@ internal sealed class InteractiveSession : IAsyncDisposable
     }
 
     /// <summary>
-    /// Gets or creates a service provider for the specified environment.
-    /// If the environment changes, the existing provider is disposed and a new one is created.
+    /// Gets or creates a service provider for the specified environment using the session's default profile.
     /// </summary>
     /// <param name="environmentUrl">The environment URL to connect to.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The service provider with connection pool.</returns>
-    public async Task<ServiceProvider> GetServiceProviderAsync(
+    public Task<ServiceProvider> GetServiceProviderAsync(
         string environmentUrl,
         CancellationToken cancellationToken = default)
     {
+        return GetServiceProviderAsync(environmentUrl, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets or creates a service provider for the specified profile and environment.
+    /// Providers are cached by (profileName, environmentUrl) — different profiles get independent providers.
+    /// </summary>
+    /// <param name="environmentUrl">The environment URL to connect to.</param>
+    /// <param name="profileName">Profile name (null to use the session's default profile).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The service provider with connection pool.</returns>
+    public async Task<ServiceProvider> GetServiceProviderAsync(
+        string environmentUrl,
+        string? profileName,
+        CancellationToken cancellationToken)
+    {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        var resolvedProfile = !string.IsNullOrEmpty(profileName) ? profileName : _profileName;
+        var cacheKey = ProviderKey(resolvedProfile, environmentUrl);
+
         // Fast path: already cached
-        if (_providers.TryGetValue(environmentUrl, out var existing))
+        if (_providers.TryGetValue(cacheKey, out var existing))
         {
-            TuiDebugLog.Log($"Reusing existing provider for {environmentUrl}");
+            TuiDebugLog.Log($"Reusing existing provider for {environmentUrl} (profile={resolvedProfile})");
             return existing;
         }
 
@@ -275,22 +322,22 @@ internal sealed class InteractiveSession : IAsyncDisposable
         try
         {
             // Double-check after lock
-            if (_providers.TryGetValue(environmentUrl, out existing))
+            if (_providers.TryGetValue(cacheKey, out existing))
             {
                 return existing;
             }
 
-            TuiDebugLog.Log($"Creating new provider for {environmentUrl}, profile={_profileName}");
+            TuiDebugLog.Log($"Creating new provider for {environmentUrl}, profile={resolvedProfile}");
 
             var provider = await _serviceProviderFactory.CreateAsync(
-                string.IsNullOrEmpty(_profileName) ? null : _profileName,
+                string.IsNullOrEmpty(resolvedProfile) ? null : resolvedProfile,
                 environmentUrl,
                 _deviceCodeCallback,
                 _beforeInteractiveAuth,
                 cancellationToken).ConfigureAwait(false);
 
-            _providers[environmentUrl] = provider;
-            TuiDebugLog.Log($"Provider created successfully for {environmentUrl}");
+            _providers[cacheKey] = provider;
+            TuiDebugLog.Log($"Provider created successfully for {environmentUrl} (profile={resolvedProfile})");
 
             // Fire-and-forget metadata preload so IntelliSense has entity names ready
             var cachedMetadata = provider.GetService<ICachedMetadataProvider>();
@@ -324,28 +371,41 @@ internal sealed class InteractiveSession : IAsyncDisposable
     }
 
     /// <summary>
-    /// Gets the SQL query service for the specified environment.
+    /// Gets the SQL query service for the specified environment using the session's default profile.
+    /// </summary>
+    public Task<ISqlQueryService> GetSqlQueryServiceAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        return GetSqlQueryServiceAsync(environmentUrl, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the SQL query service for the specified profile and environment.
     /// The underlying connection pool is reused across calls.
     /// </summary>
     /// <param name="environmentUrl">The environment URL to connect to.</param>
+    /// <param name="profileName">Profile name (null to use the session's default profile).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The SQL query service.</returns>
     public async Task<ISqlQueryService> GetSqlQueryServiceAsync(
         string environmentUrl,
-        CancellationToken cancellationToken = default)
+        string? profileName,
+        CancellationToken cancellationToken)
     {
-        var provider = await GetServiceProviderAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
+        var provider = await GetServiceProviderAsync(environmentUrl, profileName, cancellationToken).ConfigureAwait(false);
         var service = provider.GetRequiredService<ISqlQueryService>();
 
         // Wire cross-environment support: [LABEL].entity resolves via profile labels
         if (service is SqlQueryService concrete && _profileResolutionService != null)
         {
+            var capturedProfile = profileName;
             concrete.RemoteExecutorFactory = label =>
             {
                 var config = _profileResolutionService.ResolveByLabel(label);
                 if (config?.Url == null) return null;
 #pragma warning disable PPDS012 // Planner is synchronous; provider cache makes this effectively instant
-                var remoteProvider = GetServiceProviderAsync(config.Url).GetAwaiter().GetResult();
+                var remoteProvider = GetServiceProviderAsync(config.Url, capturedProfile, CancellationToken.None).GetAwaiter().GetResult();
 #pragma warning restore PPDS012
                 return remoteProvider.GetRequiredService<IQueryExecutor>();
             };
@@ -424,15 +484,17 @@ internal sealed class InteractiveSession : IAsyncDisposable
     }
 
     /// <summary>
-    /// Invalidates cached providers. If <paramref name="environmentUrl"/> is specified,
-    /// only that provider is disposed. Otherwise all providers are disposed.
+    /// Invalidates cached providers. Supports filtering by environment URL, profile name, or both.
+    /// If neither is specified, all providers are disposed.
     /// </summary>
-    /// <param name="environmentUrl">Optional URL to invalidate a specific provider.</param>
+    /// <param name="environmentUrl">Optional URL to filter by environment.</param>
+    /// <param name="profileName">Optional profile name to filter by profile.</param>
     /// <param name="caller">Automatically populated with caller method name.</param>
     /// <param name="filePath">Automatically populated with caller file path.</param>
     /// <param name="lineNumber">Automatically populated with caller line number.</param>
     public async Task InvalidateAsync(
         string? environmentUrl = null,
+        string? profileName = null,
         [CallerMemberName] string? caller = null,
         [CallerFilePath] string? filePath = null,
         [CallerLineNumber] int lineNumber = 0)
@@ -442,14 +504,29 @@ internal sealed class InteractiveSession : IAsyncDisposable
         {
             var fileName = filePath != null ? Path.GetFileName(filePath) : "unknown";
 
-            if (environmentUrl != null)
+            if (environmentUrl != null || profileName != null)
             {
-                // Invalidate specific environment
-                if (_providers.TryRemove(environmentUrl, out var provider))
+                // Invalidate matching providers
+                var keysToRemove = _providers.Keys.Where(key =>
                 {
-                    TuiDebugLog.Log($"Invalidating provider for {environmentUrl} (from {caller} at {fileName}:{lineNumber})");
-                    await provider.DisposeAsync().ConfigureAwait(false);
-                    TuiDebugLog.Log($"Provider for {environmentUrl} invalidated");
+                    var sepIndex = key.IndexOf('\0');
+                    var keyProfile = sepIndex >= 0 ? key[..sepIndex] : string.Empty;
+                    var keyEnv = sepIndex >= 0 ? key[(sepIndex + 1)..] : key;
+
+                    var profileMatch = profileName == null ||
+                        string.Equals(keyProfile, profileName, StringComparison.OrdinalIgnoreCase);
+                    var envMatch = environmentUrl == null ||
+                        string.Equals(keyEnv, environmentUrl, StringComparison.OrdinalIgnoreCase);
+                    return profileMatch && envMatch;
+                }).ToList();
+
+                foreach (var key in keysToRemove)
+                {
+                    if (_providers.TryRemove(key, out var provider))
+                    {
+                        TuiDebugLog.Log($"Invalidating provider {key} (from {caller} at {fileName}:{lineNumber})");
+                        await provider.DisposeAsync().ConfigureAwait(false);
+                    }
                 }
             }
             else
@@ -493,30 +570,37 @@ internal sealed class InteractiveSession : IAsyncDisposable
     /// The authentication flow (browser, device code) will be triggered as needed.
     /// </para>
     /// </remarks>
+    /// <param name="profileName">Profile name to re-authenticate (null for session default).</param>
+    /// <param name="environmentUrl">Environment URL to re-authenticate (null for displayed environment).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="InvalidOperationException">Thrown if no environment is currently configured.</exception>
-    public async Task InvalidateAndReauthenticateAsync(CancellationToken cancellationToken = default)
+    public async Task InvalidateAndReauthenticateAsync(
+        string? profileName = null,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(_activeEnvironmentUrl))
+        var resolvedEnv = environmentUrl ?? _activeEnvironmentUrl;
+        if (string.IsNullOrEmpty(resolvedEnv))
         {
             throw new InvalidOperationException("Cannot re-authenticate: no environment is currently configured.");
         }
 
-        var environmentUrl = _activeEnvironmentUrl;
+        var resolvedProfile = !string.IsNullOrEmpty(profileName) ? profileName : _profileName;
 
-        TuiDebugLog.Log($"Re-authenticating session for {environmentUrl}...");
+        TuiDebugLog.Log($"Re-authenticating for {resolvedEnv} (profile={resolvedProfile})...");
 
-        // Invalidate the specific environment's provider
-        await InvalidateAsync(environmentUrl).ConfigureAwait(false);
+        // Invalidate the specific (profile, environment) provider
+        await InvalidateAsync(resolvedEnv, resolvedProfile).ConfigureAwait(false);
 
         // Create a new service provider - this will trigger authentication
-        await GetServiceProviderAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
+        await GetServiceProviderAsync(resolvedEnv, resolvedProfile, cancellationToken).ConfigureAwait(false);
 
         TuiDebugLog.Log("Re-authentication complete");
     }
 
     /// <summary>
-    /// Switches to a different profile, invalidating the connection pool and optionally re-warming.
+    /// Switches to a different profile. Updates the session default and the displayed profile.
+    /// Providers are cached per (profile, environment) so no invalidation is needed.
     /// </summary>
     /// <param name="profileName">The new profile name.</param>
     /// <param name="environmentUrl">The environment URL for re-warming (optional).</param>
@@ -532,13 +616,17 @@ internal sealed class InteractiveSession : IAsyncDisposable
 
         TuiDebugLog.Log($"Switching to profile: {profileName}");
 
-        // Update the profile name for future service provider creation
+        // Update the session default profile for future tabs
         _profileName = profileName;
 
         // Load profile to get identity for status bar display
         var collection = await _profileStore.LoadAsync(cancellationToken).ConfigureAwait(false);
         var profile = collection.GetByNameOrIndex(profileName);
-        CurrentProfileIdentity = profile?.IdentityDisplay;
+        var identity = profile?.IdentityDisplay;
+
+        // Update displayed profile (for status bar)
+        _displayedProfileName = profileName;
+        _displayedProfileIdentity = identity;
 
         // Persist environment selection to profile if provided
         if (!string.IsNullOrWhiteSpace(environmentUrl))
@@ -551,29 +639,23 @@ internal sealed class InteractiveSession : IAsyncDisposable
         // Notify listeners of profile change
         ProfileChanged?.Invoke(_profileName);
 
-        // Profile change invalidates ALL cached providers since credentials differ
-        await InvalidateAsync().ConfigureAwait(false);
-
         // Update display name if provided
         if (environmentDisplayName != null)
         {
             _activeEnvironmentDisplayName = environmentDisplayName;
         }
 
-        // Re-warm with new profile credentials if environment is known
+        // Pre-warm with new profile credentials if environment is known
         if (!string.IsNullOrWhiteSpace(environmentUrl))
         {
-            // Set URL immediately so it's available to consumers
             _activeEnvironmentUrl = environmentUrl;
 
-            TuiDebugLog.Log($"Re-warming connection for {environmentDisplayName ?? environmentUrl}");
+            TuiDebugLog.Log($"Pre-warming connection for {environmentDisplayName ?? environmentUrl} (profile={profileName})");
 
-            // Notify listeners synchronously (like SetEnvironmentAsync does)
             EnvironmentChanged?.Invoke(environmentUrl, environmentDisplayName);
 
-            // Then warm pool asynchronously
             GetErrorService().FireAndForget(
-                GetServiceProviderAsync(environmentUrl, cancellationToken),
+                GetServiceProviderAsync(environmentUrl, profileName, cancellationToken),
                 "WarmAfterProfileSwitch");
         }
     }

--- a/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
@@ -84,7 +84,7 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
             });
             Application.Refresh();
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
 
             // Stale filter check: verify persisted solution still exists (first load only)
             if (_solutionFilter != null && !_staleFilterChecked)
@@ -220,7 +220,7 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
     {
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IConnectionReferenceService>();
 
             var flows = await service.GetFlowsUsingAsync(cr.LogicalName, ScreenCancellation);
@@ -339,7 +339,7 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
                 _statusLabel.Text = "Analyzing connection references...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IConnectionReferenceService>();
 
             var analysis = await service.AnalyzeAsync(
@@ -455,7 +455,7 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
     {
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var solutionService = provider.GetRequiredService<ISolutionService>();
 
             var solutionsResult = await solutionService.ListAsync(

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -84,7 +84,7 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
             });
             Application.Refresh();
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IEnvironmentVariableService>();
 
             // Validate persisted solution filter still exists (first load only)
@@ -404,7 +404,7 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
     {
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IEnvironmentVariableService>();
 
             var result = await service.SetValueAsync(schemaName, value, ScreenCancellation);
@@ -443,7 +443,7 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                 _statusLabel.Text = "Exporting environment variables...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IEnvironmentVariableService>();
 
             var export = await service.ExportAsync(
@@ -539,7 +539,7 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
     {
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var solutionService = provider.GetRequiredService<ISolutionService>();
 
             var solutionsResult = await solutionService.ListAsync(

--- a/src/PPDS.Cli/Tui/Screens/ImportJobsScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/ImportJobsScreen.cs
@@ -69,7 +69,7 @@ internal sealed class ImportJobsScreen : TuiScreenBase
             _statusLabel.Text = "Loading import jobs...";
             Application.Refresh();
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IImportJobService>();
 
             var result = await service.ListAsync(cancellationToken: ScreenCancellation);
@@ -129,7 +129,7 @@ internal sealed class ImportJobsScreen : TuiScreenBase
     {
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IImportJobService>();
 
             var data = await service.GetDataAsync(job.Id, ScreenCancellation);

--- a/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
@@ -323,7 +323,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             var result = await service.CreateTableAsync(request, reporter, ScreenCancellation);
 
@@ -360,7 +360,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             var result = await service.CreateColumnAsync(request, reporter, ScreenCancellation);
 
@@ -403,7 +403,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.CreateOneToManyAsync(request, reporter, ScreenCancellation);
 
@@ -429,7 +429,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.CreateManyToManyAsync(request, reporter, ScreenCancellation);
 
@@ -466,7 +466,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             var result = await service.CreateGlobalChoiceAsync(request, reporter, ScreenCancellation);
 
@@ -506,7 +506,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             var result = await service.CreateKeyAsync(request, reporter, ScreenCancellation);
 
@@ -581,7 +581,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.UpdateColumnAsync(request, reporter, ScreenCancellation);
 
@@ -607,7 +607,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.UpdateGlobalChoiceAsync(request, reporter, ScreenCancellation);
 
@@ -710,7 +710,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.DeleteColumnAsync(request, reporter, ScreenCancellation);
 
@@ -755,7 +755,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.DeleteRelationshipAsync(request, reporter, ScreenCancellation);
 
@@ -804,7 +804,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.DeleteKeyAsync(request, reporter, ScreenCancellation);
 
@@ -856,7 +856,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         try
         {
             var reporter = new TuiMetadataAuthoringProgressReporter(_statusLabel);
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IMetadataAuthoringService>();
             await service.DeleteGlobalChoiceAsync(request, reporter, ScreenCancellation);
 
@@ -908,7 +908,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
                 _statusLabel.Text = "Loading entities...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var provider = await GetProviderAsync(ct);
             var metadataService = provider.GetRequiredService<IMetadataQueryService>();
             var entities = await metadataService.GetEntitiesAsync(cancellationToken: ct);
 
@@ -949,7 +949,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
                 _statusLabel.Text = $"Loading {logicalName}...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var provider = await GetProviderAsync(ct);
             var metadataService = provider.GetRequiredService<IMetadataQueryService>();
 
             var (entity, globalOptionSets) = await metadataService.GetEntityWithGlobalOptionSetsAsync(

--- a/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
@@ -293,7 +293,7 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var exporter = provider.GetRequiredService<IExporter>();
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -340,7 +340,7 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var importer = provider.GetRequiredService<IImporter>();
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -416,7 +416,7 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var dataReader = provider.GetRequiredService<ICmtDataReader>();
             var graphBuilder = provider.GetRequiredService<IDependencyGraphBuilder>();
             var planBuilder = provider.GetRequiredService<IExecutionPlanBuilder>();

--- a/src/PPDS.Cli/Tui/Screens/PluginRegistrationScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/PluginRegistrationScreen.cs
@@ -140,7 +140,7 @@ internal sealed class PluginRegistrationScreen : TuiScreenBase
                 _tree.ClearObjects();
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var provider = await GetProviderAsync(ct);
             var regService = provider.GetRequiredService<IPluginRegistrationService>();
             var endpointService = provider.GetRequiredService<IServiceEndpointService>();
             var customApiService = provider.GetRequiredService<ICustomApiService>();
@@ -304,7 +304,7 @@ internal sealed class PluginRegistrationScreen : TuiScreenBase
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var regService = provider.GetRequiredService<IPluginRegistrationService>();
             var dataProviderService = provider.GetRequiredService<IDataProviderService>();
             var options = new PluginListOptions(
@@ -658,7 +658,7 @@ internal sealed class PluginRegistrationScreen : TuiScreenBase
                     : $"Enabling step: {step.Name}...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var regService = provider.GetRequiredService<IPluginRegistrationService>();
 
             if (step.IsEnabled)
@@ -767,7 +767,7 @@ internal sealed class PluginRegistrationScreen : TuiScreenBase
                 _statusLabel.Text = $"Unregistering {entityLabel}: {selected.DisplayName}...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var regService = provider.GetRequiredService<IPluginRegistrationService>();
             var endpointService = provider.GetRequiredService<IServiceEndpointService>();
             var customApiService = provider.GetRequiredService<ICustomApiService>();
@@ -863,7 +863,7 @@ internal sealed class PluginRegistrationScreen : TuiScreenBase
                 _statusLabel.Text = $"Downloading {selected.DisplayName}...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var regService = provider.GetRequiredService<IPluginRegistrationService>();
 
             byte[] content;

--- a/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
@@ -108,7 +108,7 @@ internal sealed class PluginTracesScreen : TuiScreenBase
                 _statusLabel.Text = "Loading plugin traces...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var provider = await GetProviderAsync(ct);
             var service = provider.GetRequiredService<IPluginTraceService>();
 
             var tracesResult = await service.ListAsync(filter: _currentFilter, cancellationToken: ct);
@@ -329,7 +329,7 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IPluginTraceService>();
 
             var detail = await service.GetAsync(trace.Id, ScreenCancellation);
@@ -437,7 +437,7 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IPluginTraceService>();
 
             var timeline = await service.BuildTimelineAsync(trace.CorrelationId.Value, ScreenCancellation);
@@ -513,7 +513,7 @@ internal sealed class PluginTracesScreen : TuiScreenBase
                 _statusLabel.Text = "Deleting traces...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IPluginTraceService>();
 
             int deletedCount;
@@ -558,7 +558,7 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IPluginTraceService>();
 
             var settings = await service.GetSettingsAsync(ScreenCancellation);

--- a/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
@@ -127,7 +127,7 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
                 _statusLabel.Text = "Loading solutions...";
             });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var provider = await GetProviderAsync(ct);
             var service = provider.GetRequiredService<ISolutionService>();
 
             var includeManaged = _managedCheckBox.Checked;
@@ -242,7 +242,7 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
     {
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<ISolutionService>();
 
             var components = await service.GetComponentsAsync(solution.Id, cancellationToken: ScreenCancellation);

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
@@ -20,6 +20,7 @@ internal sealed class SqlQueryPresenter : IDisposable
 
     private readonly InteractiveSession _session;
     private readonly string _environmentUrl;
+    private readonly string? _profileName;
 
     // State fields moved from SqlQueryScreen
     private string? _lastSql;
@@ -98,10 +99,11 @@ internal sealed class SqlQueryPresenter : IDisposable
     /// </summary>
     public event Action<QueryResult>? PageLoaded;
 
-    public SqlQueryPresenter(InteractiveSession session, string environmentUrl)
+    public SqlQueryPresenter(InteractiveSession session, string environmentUrl, string? profileName = null)
     {
         _session = session ?? throw new ArgumentNullException(nameof(session));
         _environmentUrl = environmentUrl ?? throw new ArgumentNullException(nameof(environmentUrl));
+        _profileName = profileName;
     }
 
     public void ToggleTds()
@@ -161,7 +163,7 @@ internal sealed class SqlQueryPresenter : IDisposable
         {
             TuiDebugLog.Log($"Getting SQL query service for URL: {_environmentUrl}");
 
-            var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, queryCt);
+            var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, _profileName, queryCt);
             TuiDebugLog.Log("Got service, executing streaming query...");
 
             // AC-13: capture and reset DML confirmation flag
@@ -292,7 +294,7 @@ internal sealed class SqlQueryPresenter : IDisposable
 
         try
         {
-            var provider = await _session.GetServiceProviderAsync(_environmentUrl, queryCt);
+            var provider = await _session.GetServiceProviderAsync(_environmentUrl, _profileName, queryCt);
             var executor = provider.GetRequiredService<IQueryExecutor>();
 
             var result = await executor.ExecuteFetchXmlAsync(fetchXml, cancellationToken: queryCt);
@@ -354,7 +356,7 @@ internal sealed class SqlQueryPresenter : IDisposable
         {
             if (_lastExecutionUsedFetchXml)
             {
-                var provider = await _session.GetServiceProviderAsync(_environmentUrl, cancellationToken);
+                var provider = await _session.GetServiceProviderAsync(_environmentUrl, _profileName, cancellationToken);
                 var executor = provider.GetRequiredService<IQueryExecutor>();
 
                 var result = await executor.ExecuteFetchXmlAsync(
@@ -370,7 +372,7 @@ internal sealed class SqlQueryPresenter : IDisposable
             }
             else
             {
-                var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, cancellationToken);
+                var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, _profileName, cancellationToken);
 
                 var request = new SqlQueryRequest
                 {
@@ -424,7 +426,7 @@ internal sealed class SqlQueryPresenter : IDisposable
     {
         try
         {
-            var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, CancellationToken.None);
+            var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, _profileName, CancellationToken.None);
             var plan = await service.ExplainAsync(sql, CancellationToken.None);
             _lastExecutionPlan = plan;
         }

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -108,7 +108,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         _deviceCodeCallback = deviceCodeCallback;
 
         // Create presenter (contains all query orchestration logic, Terminal.Gui-free)
-        _presenter = new SqlQueryPresenter(session, EnvironmentUrl ?? string.Empty);
+        _presenter = new SqlQueryPresenter(session, EnvironmentUrl ?? string.Empty, ProfileName);
 
         // Query input area
         _queryFrame = new FrameView("Query (F5 to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)")

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -636,7 +636,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         TuiDebugLog.Log($"ResolveLanguageServiceAsync starting for {EnvironmentUrl}");
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             TuiDebugLog.Log("Service provider obtained, resolving ISqlLanguageService...");
             var langService = provider.GetService<ISqlLanguageService>();
             if (langService != null)
@@ -724,7 +724,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
     /// </summary>
     private async Task HandleReauthAndRetryAsync()
     {
-        await Session.InvalidateAndReauthenticateAsync(ScreenCancellation);
+        await Session.InvalidateAndReauthenticateAsync(ProfileName, EnvironmentUrl, ScreenCancellation);
 
         TuiDebugLog.Log("Re-authentication successful, retrying query");
 
@@ -843,7 +843,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
     private async Task ShowFetchXmlDialogAsync(string sql)
     {
         // Caller guarantees EnvironmentUrl is non-null before calling this method
-        var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+        var provider = await GetProviderAsync(ScreenCancellation);
         var sqlQueryService = provider.GetRequiredService<ISqlQueryService>();
 
         var fetchXml = sqlQueryService.TranspileSql(sql);
@@ -885,7 +885,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
     {
         try
         {
-            var service = await Session.GetSqlQueryServiceAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = await GetSqlServiceAsync(ScreenCancellation);
             var plan = await service.ExplainAsync(sql, ScreenCancellation);
 
             Application.MainLoop?.Invoke(() => ShowPlanDialog(plan, 0));

--- a/src/PPDS.Cli/Tui/Screens/TuiScreenBase.cs
+++ b/src/PPDS.Cli/Tui/Screens/TuiScreenBase.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Services.Query;
 using PPDS.Cli.Tui.Infrastructure;
 using Terminal.Gui;
 
@@ -51,13 +53,19 @@ internal abstract class TuiScreenBase : ITuiScreen
     /// The environment URL this screen is bound to.
     /// Screens can operate independently on different environments.
     /// </summary>
-    public string? EnvironmentUrl { get; protected set; }
+    public string? EnvironmentUrl { get; internal set; }
 
     /// <summary>
     /// The display name of the environment this screen is bound to.
     /// Captured at construction time so it stays stable across session environment changes.
     /// </summary>
-    public string? EnvironmentDisplayName { get; protected set; }
+    public string? EnvironmentDisplayName { get; internal set; }
+
+    /// <summary>
+    /// The profile name this screen is bound to.
+    /// Each tab can independently target a different profile.
+    /// </summary>
+    public string? ProfileName { get; internal set; }
 
     /// <summary>
     /// Cancellation token that fires when the screen is closed or disposed.
@@ -71,6 +79,7 @@ internal abstract class TuiScreenBase : ITuiScreen
         ErrorService = session.GetErrorService();
         EnvironmentUrl = environmentUrl ?? session.CurrentEnvironmentUrl;
         EnvironmentDisplayName = session.CurrentEnvironmentDisplayName;
+        ProfileName = session.DefaultProfileName;
 
         Content = new View
         {
@@ -81,6 +90,18 @@ internal abstract class TuiScreenBase : ITuiScreen
             ColorScheme = TuiColorPalette.Default
         };
     }
+
+    /// <summary>
+    /// Gets the service provider for this screen's profile and environment.
+    /// </summary>
+    protected Task<ServiceProvider> GetProviderAsync(CancellationToken ct) =>
+        Session.GetServiceProviderAsync(EnvironmentUrl!, ProfileName, ct);
+
+    /// <summary>
+    /// Gets the SQL query service for this screen's profile and environment.
+    /// </summary>
+    protected Task<ISqlQueryService> GetSqlServiceAsync(CancellationToken ct) =>
+        Session.GetSqlQueryServiceAsync(EnvironmentUrl!, ProfileName, ct);
 
     /// <inheritdoc />
     public void OnActivated(IHotkeyRegistry hotkeyRegistry)

--- a/src/PPDS.Cli/Tui/Screens/TuiScreenBase.cs
+++ b/src/PPDS.Cli/Tui/Screens/TuiScreenBase.cs
@@ -94,14 +94,22 @@ internal abstract class TuiScreenBase : ITuiScreen
     /// <summary>
     /// Gets the service provider for this screen's profile and environment.
     /// </summary>
-    protected Task<ServiceProvider> GetProviderAsync(CancellationToken ct) =>
-        Session.GetServiceProviderAsync(EnvironmentUrl!, ProfileName, ct);
+    protected Task<ServiceProvider> GetProviderAsync(CancellationToken ct)
+    {
+        if (EnvironmentUrl is null)
+            throw new InvalidOperationException("Cannot get service provider: screen has no bound environment.");
+        return Session.GetServiceProviderAsync(EnvironmentUrl, ProfileName, ct);
+    }
 
     /// <summary>
     /// Gets the SQL query service for this screen's profile and environment.
     /// </summary>
-    protected Task<ISqlQueryService> GetSqlServiceAsync(CancellationToken ct) =>
-        Session.GetSqlQueryServiceAsync(EnvironmentUrl!, ProfileName, ct);
+    protected Task<ISqlQueryService> GetSqlServiceAsync(CancellationToken ct)
+    {
+        if (EnvironmentUrl is null)
+            throw new InvalidOperationException("Cannot get SQL query service: screen has no bound environment.");
+        return Session.GetSqlQueryServiceAsync(EnvironmentUrl, ProfileName, ct);
+    }
 
     /// <inheritdoc />
     public void OnActivated(IHotkeyRegistry hotkeyRegistry)

--- a/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
@@ -104,7 +104,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
             _statusLabel.Text = $"Loading {filterLabel}web resources...";
             Application.Refresh();
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var provider = await GetProviderAsync(ct);
             var service = provider.GetRequiredService<IWebResourceService>();
 
             // Stale reference check: verify persisted solution still exists (first load only)
@@ -207,7 +207,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
     {
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IWebResourceService>();
 
             var content = await service.GetContentAsync(resource.Id, false, ScreenCancellation);
@@ -288,7 +288,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
             _statusLabel.Text = $"Publishing {resource.Name}...";
             Application.Refresh();
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IWebResourceService>();
 
             var count = await service.PublishAsync([resource.Id], ScreenCancellation);
@@ -329,7 +329,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
             _statusLabel.Text = "Publishing all customizations...";
             Application.Refresh();
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var service = provider.GetRequiredService<IWebResourceService>();
 
             await service.PublishAllAsync(ScreenCancellation);
@@ -362,7 +362,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
 
         try
         {
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await GetProviderAsync(ScreenCancellation);
             var solutionService = provider.GetRequiredService<ISolutionService>();
 
             var solutionsResult = await solutionService.ListAsync(cancellationToken: ScreenCancellation);

--- a/src/PPDS.Cli/Tui/Testing/States/TabManagerState.cs
+++ b/src/PPDS.Cli/Tui/Testing/States/TabManagerState.cs
@@ -14,4 +14,5 @@ public sealed record TabSummary(
     string? EnvironmentUrl,
     EnvironmentType EnvironmentType,
     EnvironmentColor EnvironmentColor,
-    bool IsActive);
+    bool IsActive,
+    string? ProfileName);

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -785,7 +785,8 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
         }
 
         var displayName = _session.CurrentEnvironmentDisplayName;
-        using var dialog = new EnvironmentDetailsDialog(_session, url, displayName);
+        var profileName = (_currentScreen as TuiScreenBase)?.ProfileName;
+        using var dialog = new EnvironmentDetailsDialog(_session, url, displayName, profileName);
         Application.Run(dialog);
     }
 
@@ -877,38 +878,6 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
                     profile.Identity,
                     profile.EnvironmentUrl,
                     profile.EnvironmentName);
-            }
-
-            _statusBar.Refresh();
-        });
-    }
-
-    private async Task SetActiveProfileWithEnvironmentAsync(ProfileSummary profile, string? environmentUrl, string? environmentName)
-    {
-        await _session.SetActiveProfileAsync(
-            profile.DisplayIdentifier,
-            environmentUrl,
-            environmentName);
-
-        Application.MainLoop?.Invoke(() =>
-        {
-            // Update the active tab's profile binding
-            var activeIndex = _tabManager.ActiveIndex;
-            if (activeIndex >= 0)
-            {
-                if (_currentScreen is TuiScreenBase screenBase)
-                {
-                    screenBase.ProfileName = profile.DisplayIdentifier;
-                    screenBase.EnvironmentUrl = environmentUrl;
-                    screenBase.EnvironmentDisplayName = environmentName;
-                }
-
-                _tabManager.UpdateTabProfile(
-                    activeIndex,
-                    profile.DisplayIdentifier,
-                    profile.Identity,
-                    environmentUrl,
-                    environmentName);
             }
 
             _statusBar.Refresh();

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -112,11 +112,14 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
         // Hide splash if still showing
         HideSplash();
 
-        // Add screen as a new tab — AddTab fires ActiveTabChanged,
-        // which calls OnActiveTabChanged to handle activation.
-        var envUrl = (screen as TuiScreenBase)?.EnvironmentUrl ?? _session.CurrentEnvironmentUrl;
-        var envName = _session.CurrentEnvironmentDisplayName;
-        _tabManager.AddTab(screen, envUrl, envName);
+        // Capture profile and environment from the screen (set at construction)
+        var screenBase = screen as TuiScreenBase;
+        var envUrl = screenBase?.EnvironmentUrl ?? _session.CurrentEnvironmentUrl;
+        var envName = screenBase?.EnvironmentDisplayName ?? _session.CurrentEnvironmentDisplayName;
+        var profileName = screenBase?.ProfileName ?? _session.DefaultProfileName;
+        var profileIdentity = _session.CurrentProfileIdentity;
+
+        _tabManager.AddTab(screen, envUrl, envName, profileName, profileIdentity);
     }
 
     private void OnScreenCloseRequested()
@@ -197,7 +200,8 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
         _contentArea.Add(_currentScreen.Content);
         _currentScreen.OnActivated(_hotkeyRegistry);
 
-        // Sync status bar to reflect this tab's environment
+        // Sync status bar to reflect this tab's profile and environment
+        _session.UpdateDisplayedProfile(activeTab.ProfileName, activeTab.ProfileIdentity);
         _session.UpdateDisplayedEnvironment(activeTab.EnvironmentUrl, activeTab.EnvironmentDisplayName);
 
         RebuildMenuBar();
@@ -689,7 +693,9 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
 
         if (dialog.SelectedProfile != null)
         {
-            _errorService.FireAndForget(SetActiveProfileAsync(dialog.SelectedProfile), "SwitchProfile");
+            _errorService.FireAndForget(
+                SetActiveProfileForTabAsync(dialog.SelectedProfile),
+                "SwitchProfile");
         }
         else if (dialog.CreateNewSelected)
         {
@@ -832,19 +838,18 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             var envUrl = dialog.SelectedEnvironmentUrl ?? dialog.CreatedProfile.EnvironmentUrl;
             var envName = dialog.SelectedEnvironmentName ?? dialog.CreatedProfile.EnvironmentName;
 
-            // Prompt to configure the environment if unconfigured
             if (envUrl != null)
             {
                 PromptToConfigureIfNeeded(envUrl, envName, discoveredType: null);
             }
 
             _errorService.FireAndForget(
-                SetActiveProfileWithEnvironmentAsync(dialog.CreatedProfile, envUrl, envName),
+                SetActiveProfileForTabAsync(dialog.CreatedProfile),
                 "ProfileCreation");
         }
     }
 
-    private async Task SetActiveProfileAsync(ProfileSummary profile)
+    private async Task SetActiveProfileForTabAsync(ProfileSummary profile)
     {
         await _session.SetActiveProfileAsync(
             profile.DisplayIdentifier,
@@ -853,6 +858,27 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
 
         Application.MainLoop?.Invoke(() =>
         {
+            // Update the active tab's profile binding
+            var activeIndex = _tabManager.ActiveIndex;
+            if (activeIndex >= 0)
+            {
+                // Update the screen's profile and environment
+                if (_currentScreen is TuiScreenBase screenBase)
+                {
+                    screenBase.ProfileName = profile.DisplayIdentifier;
+                    screenBase.EnvironmentUrl = profile.EnvironmentUrl;
+                    screenBase.EnvironmentDisplayName = profile.EnvironmentName;
+                }
+
+                // Update tab info
+                _tabManager.UpdateTabProfile(
+                    activeIndex,
+                    profile.DisplayIdentifier,
+                    profile.Identity,
+                    profile.EnvironmentUrl,
+                    profile.EnvironmentName);
+            }
+
             _statusBar.Refresh();
         });
     }
@@ -866,6 +892,25 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
 
         Application.MainLoop?.Invoke(() =>
         {
+            // Update the active tab's profile binding
+            var activeIndex = _tabManager.ActiveIndex;
+            if (activeIndex >= 0)
+            {
+                if (_currentScreen is TuiScreenBase screenBase)
+                {
+                    screenBase.ProfileName = profile.DisplayIdentifier;
+                    screenBase.EnvironmentUrl = environmentUrl;
+                    screenBase.EnvironmentDisplayName = environmentName;
+                }
+
+                _tabManager.UpdateTabProfile(
+                    activeIndex,
+                    profile.DisplayIdentifier,
+                    profile.Identity,
+                    environmentUrl,
+                    environmentName);
+            }
+
             _statusBar.Refresh();
         });
     }

--- a/src/PPDS.Cli/Tui/Views/TabBar.cs
+++ b/src/PPDS.Cli/Tui/Views/TabBar.cs
@@ -57,15 +57,27 @@ internal sealed class TabBar : View, ITuiStateCapture<TabBarState>
 
             if (_tabManager.TabCount == 0) return;
 
+            // Determine if multiple profiles are in use — show profile prefix only when needed
+            var profileNames = _tabManager.Tabs
+                .Select(t => t.ProfileName)
+                .Where(p => !string.IsNullOrEmpty(p))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var showProfile = profileNames.Count > 1;
+
             var xPos = 0;
             for (int i = 0; i < _tabManager.Tabs.Count; i++)
             {
                 var tab = _tabManager.Tabs[i];
                 var index = i; // Capture for closure
                 var envLabel = _themeService.GetEnvironmentLabelForUrl(tab.EnvironmentUrl);
-                var text = string.IsNullOrEmpty(envLabel)
-                    ? $" {i + 1}: {tab.Screen.Title} "
-                    : $" {i + 1}: {tab.Screen.Title} [{envLabel}] ";
+                var contextParts = new List<string>();
+                if (showProfile && !string.IsNullOrEmpty(tab.ProfileName))
+                    contextParts.Add(tab.ProfileName);
+                if (!string.IsNullOrEmpty(envLabel))
+                    contextParts.Add(envLabel);
+                var context = contextParts.Count > 0 ? $" [{string.Join(" / ", contextParts)}]" : "";
+                var text = $" {i + 1}: {tab.Screen.Title}{context} ";
 
                 var isActive = i == _tabManager.ActiveIndex;
                 // Active tabs get bracket markers for clear visual distinction

--- a/tests/PPDS.Cli.Tests/Tui/Infrastructure/TabManagerTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Infrastructure/TabManagerTests.cs
@@ -53,8 +53,8 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void AddTab_MultipleTabs_LastIsActive()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
 
         Assert.Equal(2, _manager.TabCount);
         Assert.Equal(1, _manager.ActiveIndex);
@@ -63,8 +63,8 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void ActivateTab_SwitchesActive()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
 
         _manager.ActivateTab(0);
 
@@ -74,9 +74,9 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void CloseTab_RemovesAndActivatesAdjacent()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
-        _manager.AddTab(new StubScreen(_session), "https://qa.crm4.dynamics.com", "QA");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://qa.crm4.dynamics.com", "QA", "TestProfile");
 
         _manager.ActivateTab(1); // PROD active
         _manager.CloseTab(1);    // Close PROD
@@ -89,8 +89,8 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void CloseTab_LastTab_ActivatesPrevious()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
 
         _manager.ActivateTab(1); // PROD active
         _manager.CloseTab(1);    // Close last tab
@@ -102,7 +102,7 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void CloseTab_OnlyTab_NoActive()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
         _manager.CloseTab(0);
 
         Assert.Equal(0, _manager.TabCount);
@@ -124,9 +124,9 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void ActivateNext_Cycles()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
-        _manager.AddTab(new StubScreen(_session), "https://qa.crm4.dynamics.com", "QA");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://qa.crm4.dynamics.com", "QA", "TestProfile");
         _manager.ActivateTab(0);
 
         _manager.ActivateNext();
@@ -142,8 +142,8 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void ActivatePrevious_Cycles()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
         _manager.ActivateTab(0);
 
         _manager.ActivatePrevious(); // Wraps
@@ -156,7 +156,7 @@ public sealed class TabManagerTests : IDisposable
         var count = 0;
         _manager.TabsChanged += () => count++;
 
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
         _manager.CloseTab(0);
 
         Assert.Equal(2, count);
@@ -168,8 +168,8 @@ public sealed class TabManagerTests : IDisposable
         var count = 0;
         _manager.ActiveTabChanged += () => count++;
 
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
         _manager.ActivateTab(0);
 
         Assert.True(count >= 3); // Add activates + explicit switch
@@ -178,8 +178,8 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void CaptureState_ReflectsTabs()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
 
         var state = _manager.CaptureState();
 
@@ -195,8 +195,8 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void FindTabByEnvironment_ReturnsIndex_WhenTabExists()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
-        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
 
         Assert.Equal(0, _manager.FindTabByEnvironment("https://dev.crm.dynamics.com"));
         Assert.Equal(1, _manager.FindTabByEnvironment("https://prod.crm.dynamics.com"));
@@ -205,7 +205,7 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void FindTabByEnvironment_CaseInsensitive()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
 
         Assert.Equal(0, _manager.FindTabByEnvironment("https://DEV.CRM.DYNAMICS.COM"));
     }
@@ -213,7 +213,7 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void FindTabByEnvironment_ReturnsNegativeOne_WhenNotFound()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
 
         Assert.Equal(-1, _manager.FindTabByEnvironment("https://prod.crm.dynamics.com"));
     }
@@ -221,7 +221,7 @@ public sealed class TabManagerTests : IDisposable
     [Fact]
     public void FindTabByEnvironment_ReturnsNegativeOne_WhenNull()
     {
-        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV");
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
 
         Assert.Equal(-1, _manager.FindTabByEnvironment(null));
     }
@@ -232,7 +232,7 @@ public sealed class TabManagerTests : IDisposable
         var themeService = new ConfigurableThemeService();
         using var manager = new TabManager(themeService);
 
-        manager.AddTab(new StubScreen(_session), "https://org.crm.dynamics.com", "ORG");
+        manager.AddTab(new StubScreen(_session), "https://org.crm.dynamics.com", "ORG", "TestProfile");
         Assert.Equal(EnvironmentColor.Green, manager.Tabs[0].EnvironmentColor);
 
         // Change what the theme service returns
@@ -249,7 +249,7 @@ public sealed class TabManagerTests : IDisposable
     {
         var themeService = new ConfigurableThemeService();
         using var manager = new TabManager(themeService);
-        manager.AddTab(new StubScreen(_session), "https://org.crm.dynamics.com", "ORG");
+        manager.AddTab(new StubScreen(_session), "https://org.crm.dynamics.com", "ORG", "TestProfile");
 
         var fired = false;
         manager.TabsChanged += () => fired = true;
@@ -265,7 +265,7 @@ public sealed class TabManagerTests : IDisposable
     {
         var themeService = new ConfigurableThemeService();
         using var manager = new TabManager(themeService);
-        manager.AddTab(new StubScreen(_session), "https://org.crm.dynamics.com", "ORG");
+        manager.AddTab(new StubScreen(_session), "https://org.crm.dynamics.com", "ORG", "TestProfile");
 
         var fired = false;
         manager.TabsChanged += () => fired = true;
@@ -280,6 +280,85 @@ public sealed class TabManagerTests : IDisposable
     public void RefreshTabColors_NoTabs_NoErrors()
     {
         _manager.RefreshTabColors(); // Should not throw
+    }
+
+    [Fact]
+    public void AddTab_StoresProfileName()
+    {
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "DevProfile", "josh@contoso.com");
+
+        Assert.Equal("DevProfile", _manager.ActiveTab?.ProfileName);
+        Assert.Equal("josh@contoso.com", _manager.ActiveTab?.ProfileIdentity);
+    }
+
+    [Fact]
+    public void AddTab_DifferentProfiles_IndependentTabs()
+    {
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "ProfileA", "user-a@contoso.com");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "ProfileB", "user-b@contoso.com");
+
+        Assert.Equal("ProfileB", _manager.Tabs[1].ProfileName);
+        Assert.Equal("ProfileA", _manager.Tabs[0].ProfileName);
+    }
+
+    [Fact]
+    public void UpdateTabProfile_ChangesProfileAndEnvironment()
+    {
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "OldProfile", "old@contoso.com");
+
+        _manager.UpdateTabProfile(0, "NewProfile", "new@contoso.com", "https://prod.crm.dynamics.com", "PROD");
+
+        Assert.Equal("NewProfile", _manager.Tabs[0].ProfileName);
+        Assert.Equal("new@contoso.com", _manager.Tabs[0].ProfileIdentity);
+        Assert.Equal("https://prod.crm.dynamics.com", _manager.Tabs[0].EnvironmentUrl);
+        Assert.Equal("PROD", _manager.Tabs[0].EnvironmentDisplayName);
+    }
+
+    [Fact]
+    public void UpdateTabProfile_FiresTabsChanged()
+    {
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        var fired = false;
+        _manager.TabsChanged += () => fired = true;
+
+        _manager.UpdateTabProfile(0, "NewProfile", null, "https://dev.crm.dynamics.com", "DEV");
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void UpdateTabProfile_ActiveTab_FiresActiveTabChanged()
+    {
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        var fired = false;
+        _manager.ActiveTabChanged += () => fired = true;
+
+        _manager.UpdateTabProfile(0, "NewProfile", null, "https://dev.crm.dynamics.com", "DEV");
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void UpdateTabProfile_InactiveTab_DoesNotFireActiveTabChanged()
+    {
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "TestProfile");
+        _manager.AddTab(new StubScreen(_session), "https://prod.crm.dynamics.com", "PROD", "TestProfile");
+        var fired = false;
+        _manager.ActiveTabChanged += () => fired = true;
+
+        _manager.UpdateTabProfile(0, "NewProfile", null, "https://dev.crm.dynamics.com", "DEV");
+
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void CaptureState_IncludesProfileName()
+    {
+        _manager.AddTab(new StubScreen(_session), "https://dev.crm.dynamics.com", "DEV", "MyProfile");
+
+        var state = _manager.CaptureState();
+
+        Assert.Equal("MyProfile", state.Tabs[0].ProfileName);
     }
 
     private sealed class StubScreen : TuiScreenBase


### PR DESCRIPTION
## Summary
- Individual TUI tabs can now target different authentication profiles with independent service providers keyed by (profile, environment) composite cache keys
- Tab bar shows profile prefix (e.g., `[ProfileA / DEV]`) when multiple profiles are in use; status bar syncs to active tab's profile on switch
- SqlQueryPresenter and EnvironmentDetailsDialog propagate per-tab profile for correct credential isolation

Closes #927

## Test Plan
- [x] 7 new TabManager unit tests for profile storage, update, events, and state capture
- [x] All 3312 CLI unit tests pass across net8.0/net9.0/net10.0
- [x] TUI interactive verification: tab bar rendering, status bar sync, tab switching
- [x] TUI E2E snapshot tests pass (4 snapshots)

## Verification
- [x] /gates passed
- [x] /verify tui completed
- [x] Pre-PR self-review completed (1 DEFECT fixed, 3 CONCERNs addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)