### PR TITLE
fix: disable procode-toolkit plugin for ppds repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
-    "superpowers@claude-plugins-official": false
+    "superpowers@claude-plugins-official": false,
+    "procode-toolkit@procode-toolkit": false
   },
   "safety": {
     "shakedown_safe_envs": [


### PR DESCRIPTION
## Summary
- Disable procode-toolkit plugin at the project level — its `skill-redirect` hook conflicts with ppds's own local skills (`/start`, `/pr`, etc.) by blocking `git worktree add` and other commands
- procode-toolkit remains enabled globally for other repos via user-level settings

## Context
Retro finding from PR #933 session: procode-toolkit hooks were intercepting worktree creation and redirecting to its own `/create-worktree` skill, preventing the local `/start` skill from functioning.

## Test plan
- [ ] Relaunch Claude Code in ppds — confirm procode-toolkit skills no longer appear
- [ ] Confirm local `/start` skill works (creates worktree without hook block)
- [ ] Confirm procode-toolkit still works in other repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)