### PR TITLE
fix(hooks): enforce /pr skill in all worktree sessions

### DIFF
--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -11,15 +11,16 @@ Commit-aware validation (v8.0):
   - Workflow-only diffs skip QA requirement
   - Triage completeness when PR already exists in state
 
-Agent-entry-point enforcement (v9.0):
-  - Agent-context PR creation MUST go through the `/pr` skill.
-  - Agent context = cwd inside ``.claude/worktrees/agent-*`` OR one of the
-    Claude Code agent env vars (``CLAUDE_CODE_AGENT``, ``CLAUDE_AGENT_ID``,
+Worktree entry-point enforcement (v9.1 — R-01 retro fix):
+  - Worktree PR creation MUST go through the ``/pr`` skill.
+  - Worktree context = cwd inside ``.worktrees/`` (project-level) OR
+    ``.claude/worktrees/`` (Claude Code worktrees) OR one of the Claude Code
+    agent env vars (``CLAUDE_CODE_AGENT``, ``CLAUDE_AGENT_ID``,
     ``CLAUDE_CODE_SUBAGENT``) set.
-  - Agent context requires ``pr.invoked_via_skill=true`` in workflow state;
+  - Worktree context requires ``pr.invoked_via_skill=true`` in workflow state;
     the ``/pr`` skill sets this marker at entry.
-  - Human context (main checkout, no agent env vars) keeps the previous
-    behavior -- workflow-step validation only.
+  - Human context (main checkout, no agent env vars, no worktree path) keeps
+    the previous behavior -- workflow-step validation only.
   - Explicit override: ``PPDS_PR_GATE_HUMAN=1`` forces human context for
     the rare case of a human running ``gh pr create`` from a worktree.
 """
@@ -48,11 +49,12 @@ _HUMAN_OVERRIDE_ENV = "PPDS_PR_GATE_HUMAN"
 
 
 def _is_agent_context(cwd=None, env=None):
-    """Return True if this invocation looks like a Claude Code agent.
+    """Return True if this invocation looks like a Claude Code session in a worktree.
 
     Heuristics (any one triggers agent context):
-      1. cwd path contains ``.claude/worktrees/agent-`` segment
-      2. Any known Claude Code agent env var is set to a non-empty value
+      1. cwd is inside a ``.worktrees/`` directory (project-level worktrees)
+      2. cwd is inside ``.claude/worktrees/`` (Claude Code worktrees)
+      3. Any known Claude Code agent env var is set to a non-empty value
 
     The explicit override ``PPDS_PR_GATE_HUMAN=1`` forces False regardless.
     """
@@ -68,7 +70,7 @@ def _is_agent_context(cwd=None, env=None):
     # Fall back to path sniffing. Normalize to forward slashes.
     cwd = cwd if cwd is not None else os.getcwd()
     normalized = cwd.replace("\\", "/")
-    if "/.claude/worktrees/agent-" in normalized:
+    if "/.worktrees/" in normalized or "/.claude/worktrees/" in normalized:
         return True
     return False
 

--- a/scripts/verify-workflow.py
+++ b/scripts/verify-workflow.py
@@ -331,7 +331,9 @@ def test_pr_gate_allows(ctx: ScenarioContext) -> ScenarioResult:
         "review": {"passed": "2026-03-28T00:00:00Z", "commit_ref": head_sha},
     })
     stdin = {"tool_input": {"command": "gh pr create --title 'test' --body 'test'"}}
-    result = ctx.run_hook("pr-gate.py", stdin_json=stdin)
+    # Force human context — this scenario tests commit-ref validation, not agent enforcement.
+    # Running from a .worktrees/ path would otherwise trigger agent-context detection.
+    result = ctx.run_hook("pr-gate.py", stdin_json=stdin, env_override={"PPDS_PR_GATE_HUMAN": "1"})
     if result.returncode != 0:
         return fail(ctx, f"Expected exit 0, got {result.returncode}. stderr: {result.stderr[:200]}")
     return pass_result(ctx)
@@ -450,7 +452,8 @@ def test_commit_ref_validation(ctx: ScenarioContext) -> ScenarioResult:
         "qa": {},  # workflow-only, no QA needed
         "review": {"passed": "2026-03-28T00:00:00Z", "commit_ref": head_sha},
     })
-    result = ctx.run_hook("pr-gate.py", stdin_json=stdin)
+    # Force human context — this scenario tests commit-ref validation, not agent enforcement.
+    result = ctx.run_hook("pr-gate.py", stdin_json=stdin, env_override={"PPDS_PR_GATE_HUMAN": "1"})
     if result.returncode != 0:
         return fail(ctx, f"Expected exit 0 for correct commit_ref, got {result.returncode}. stderr: {result.stderr[:300]}")
 
@@ -474,7 +477,8 @@ def test_workflow_only_no_qa(ctx: ScenarioContext) -> ScenarioResult:
         "review": {"passed": "2026-03-28T00:00:00Z", "commit_ref": head_sha},
     })
     stdin = {"tool_input": {"command": "gh pr create --title 'test' --body 'test'"}}
-    result = ctx.run_hook("pr-gate.py", stdin_json=stdin)
+    # Force human context — this scenario tests QA exemption, not agent enforcement.
+    result = ctx.run_hook("pr-gate.py", stdin_json=stdin, env_override={"PPDS_PR_GATE_HUMAN": "1"})
     if result.returncode != 0:
         return fail(ctx, f"Expected exit 0 for workflow-only diff (no QA needed), got {result.returncode}. stderr: {result.stderr[:300]}")
 

--- a/tests/hooks/test_pr_gate_agent_enforcement.py
+++ b/tests/hooks/test_pr_gate_agent_enforcement.py
@@ -125,6 +125,15 @@ import pytest
     ("/x", {"CLAUDE_CODE_AGENT": "1", "PPDS_PR_GATE_HUMAN": "1"}, False),
     # Override value != "1" does not override
     ("/home/j/ppds/.claude/worktrees/agent-abcd", {"PPDS_PR_GATE_HUMAN": "true"}, True),
+    # Project-level .worktrees/ paths (R-01 retro finding from PR #933)
+    ("/home/j/ppds/.worktrees/toolbar-search-consistency", {}, True),
+    ("/home/j/ppds/.worktrees/pr-gate-worktree-enforcement", {}, True),
+    (r"C:\Users\josh\ppds\.worktrees\some-feature", {}, True),
+    ("/home/j/ppds/.worktrees/toolbar-search-consistency/src", {}, True),
+    # Human override beats .worktrees/ path too
+    ("/home/j/ppds/.worktrees/toolbar-search-consistency", {"PPDS_PR_GATE_HUMAN": "1"}, False),
+    # Non-agent .claude/worktrees/ (not just agent-* prefix)
+    ("/home/j/ppds/.claude/worktrees/review-1234", {}, True),
 ])
 def test_is_agent_context(cwd, env, expected):
     assert hook._is_agent_context(cwd=cwd, env=env) is expected
@@ -168,6 +177,26 @@ class TestAgentBlockedWithoutMarker:
         assert r.returncode == 2, r.stderr
         assert "must go through the `/pr` skill" in r.stderr
 
+    def test_worktree_cwd_no_state_blocks(self, tmp_path):
+        """R-01 regression: project-level .worktrees/ must enforce /pr skill."""
+        wt_dir = tmp_path / ".worktrees" / "toolbar-search-consistency"
+        wt_dir.mkdir(parents=True)
+        _init_repo(wt_dir)
+        r = _run_hook("gh pr create --draft", cwd=wt_dir)
+        assert r.returncode == 2, r.stderr
+        assert "must go through the `/pr` skill" in r.stderr
+
+    def test_worktree_cwd_with_full_state_but_no_marker_blocks(self, tmp_path):
+        """R-01 regression: worktree + full state but no /pr marker -> blocked."""
+        wt_dir = tmp_path / ".worktrees" / "feature-branch"
+        wt_dir.mkdir(parents=True)
+        _init_repo(wt_dir)
+        head = _git(wt_dir, ["rev-parse", "HEAD"]).strip()
+        _write_state(wt_dir, _passing_state(head))
+        r = _run_hook("gh pr create --draft -t t -b b", cwd=wt_dir)
+        assert r.returncode == 2, r.stderr
+        assert "must go through the `/pr` skill" in r.stderr
+
 
 class TestAgentAllowedWithMarker:
     def test_agent_with_marker_and_full_state_passes(self, tmp_path):
@@ -181,6 +210,19 @@ class TestAgentAllowedWithMarker:
             cwd=tmp_path,
             env_extra={"CLAUDE_CODE_AGENT": "1"},
         )
+        assert r.returncode == 0, r.stderr
+        assert "must go through the `/pr` skill" not in r.stderr
+
+    def test_worktree_with_marker_and_full_state_passes(self, tmp_path):
+        """R-01 regression: worktree + /pr marker + full state -> allowed."""
+        wt_dir = tmp_path / ".worktrees" / "feature-branch"
+        wt_dir.mkdir(parents=True)
+        _init_repo(wt_dir)
+        head = _git(wt_dir, ["rev-parse", "HEAD"]).strip()
+        state = _passing_state(head)
+        state["pr"] = {"invoked_via_skill": True}
+        _write_state(wt_dir, state)
+        r = _run_hook("gh pr create --draft -t t -b b", cwd=wt_dir)
         assert r.returncode == 0, r.stderr
         assert "must go through the `/pr` skill" not in r.stderr
 


### PR DESCRIPTION
## Summary
- Expands `_is_agent_context()` in `pr-gate.py` to detect **all** `.worktrees/` paths (not just `.claude/worktrees/agent-*`), so any Claude session in a project-level worktree must go through the `/pr` skill
- Also broadens `.claude/worktrees/` detection to match all worktrees (not just `agent-*` prefix)
- Fixes 3 behavioral scenarios in `verify-workflow.py` that test human-context PR gate behavior — they now use `PPDS_PR_GATE_HUMAN=1` since running from a `.worktrees/` path correctly triggers agent context

**Retro finding R-01 from PR #933 session:** assistant completed /gates and /verify via Skill tool, then manually ran `gh pr create` instead of invoking `/pr`, bypassing the full lifecycle (Gemini review wait, triage, etc.).

## Test Plan
- [x] 6 new parametrized unit tests for `.worktrees/` and `.claude/worktrees/` path detection
- [x] 4 new end-to-end tests (worktree blocked without marker, worktree blocked with state but no marker, worktree passes with marker)
- [x] All 31 pr-gate agent enforcement tests pass
- [x] All 9 verify-workflow behavioral scenarios pass
- [x] All 176 hook-related tests pass

## Verification
- [x] /gates passed (workflow surface)
- [x] /verify completed (workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)