### PR TITLE
fix(docs-release): build individual projects to avoid NETSDK1194

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -50,21 +50,22 @@ jobs:
 
       - name: Build
         run: |
-          dotnet build PPDS.sln -c Release -o artifacts/bin
-          ls artifacts/bin/PPDS.Cli.dll
-          ls artifacts/bin/PPDS.Mcp.dll
+          dotnet build src/PPDS.Cli/PPDS.Cli.csproj -c Release -f net10.0 -o artifacts/bin
+          dotnet build src/PPDS.Mcp/PPDS.Mcp.csproj -c Release -f net10.0 -o artifacts/bin
+          ls artifacts/bin/ppds.dll
+          ls artifacts/bin/ppds-mcp-server.dll
 
       - name: Generate reference markdown
         run: |
           mkdir -p artifacts/docs
           dotnet run --project scripts/docs-gen/cli-reflect -c Release -- \
-            --assembly artifacts/bin/PPDS.Cli.dll \
+            --assembly artifacts/bin/ppds.dll \
             --output artifacts/docs/reference/cli
           dotnet run --project scripts/docs-gen/libs-reflect -c Release -- \
             --assemblies artifacts/bin \
             --output artifacts/docs/reference/libraries
           dotnet run --project scripts/docs-gen/mcp-reflect -c Release -- \
-            --assembly artifacts/bin/PPDS.Mcp.dll \
+            --assembly artifacts/bin/ppds-mcp-server.dll \
             --output artifacts/docs/reference/mcp
           node scripts/docs-gen/ext-reflect/generate.js \
             --package-json src/PPDS.Extension/package.json \

--- a/tests/PPDS.LiveTests.Fixtures/PPDS.LiveTests.Fixtures.csproj
+++ b/tests/PPDS.LiveTests.Fixtures/PPDS.LiveTests.Fixtures.csproj
@@ -27,13 +27,13 @@
   <!-- Copy DLL and dependencies to TestData after build -->
   <Target Name="CopyToTestData" AfterTargets="Build">
     <MakeDir Directories="..\PPDS.LiveTests\TestData" />
-    <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll"
+    <Copy SourceFiles="$(TargetDir)$(AssemblyName).dll"
           DestinationFolder="..\PPDS.LiveTests\TestData\" />
-    <Copy SourceFiles="$(OutputPath)$(AssemblyName).pdb"
+    <Copy SourceFiles="$(TargetDir)$(AssemblyName).pdb"
           DestinationFolder="..\PPDS.LiveTests\TestData\"
-          Condition="Exists('$(OutputPath)$(AssemblyName).pdb')" />
+          Condition="Exists('$(TargetDir)$(AssemblyName).pdb')" />
     <!-- Copy PPDS.Plugins.dll for MetadataLoadContext resolution -->
-    <Copy SourceFiles="$(OutputPath)PPDS.Plugins.dll"
+    <Copy SourceFiles="$(TargetDir)PPDS.Plugins.dll"
           DestinationFolder="..\PPDS.LiveTests\TestData\" />
   </Target>
 

--- a/tests/ci/test_docs_release_workflow.py
+++ b/tests/ci/test_docs_release_workflow.py
@@ -1,0 +1,80 @@
+"""Tests for docs-release.yml workflow build configuration.
+
+Verifies that the build step targets specific projects (not the entire
+solution) and references the correct assembly names for the reflectors.
+
+Root cause: dotnet build PPDS.sln -c Release -o artifacts/bin triggers
+NETSDK1194 — test projects race-write runtimeconfig.json into the shared
+output directory, causing IO failures.
+
+Run with: python -m pytest tests/ci/test_docs_release_workflow.py -v
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docs-release.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    """Parse the workflow YAML once per module."""
+    if not WORKFLOW_PATH.exists():
+        pytest.fail(f"docs-release.yml not found at {WORKFLOW_PATH}")
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    """Raw text of the workflow for pattern-based assertions."""
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_build_does_not_target_solution(workflow_text: str) -> None:
+    """The build step must NOT run 'dotnet build PPDS.sln' with -o.
+
+    NETSDK1194: The --output option isn't supported when building a
+    solution. All projects race-write to the same dir causing IO failures.
+    """
+    assert "dotnet build PPDS.sln" not in workflow_text, (
+        "Build must target individual projects, not the solution. "
+        "dotnet build PPDS.sln -o triggers NETSDK1194."
+    )
+
+
+def test_build_targets_specific_projects(workflow_text: str) -> None:
+    """Build step must explicitly build PPDS.Cli and PPDS.Mcp projects."""
+    assert "PPDS.Cli.csproj" in workflow_text or "PPDS.Cli/" in workflow_text, (
+        "Build step must target PPDS.Cli project explicitly"
+    )
+    assert "PPDS.Mcp.csproj" in workflow_text or "PPDS.Mcp/" in workflow_text, (
+        "Build step must target PPDS.Mcp project explicitly"
+    )
+
+
+def test_cli_assembly_name_is_correct(workflow_text: str) -> None:
+    """cli-reflect must reference ppds.dll (PPDS.Cli's AssemblyName is 'ppds')."""
+    assert "ppds.dll" in workflow_text, (
+        "cli-reflect must use the actual assembly name ppds.dll, "
+        "not PPDS.Cli.dll"
+    )
+
+
+def test_mcp_assembly_name_is_correct(workflow_text: str) -> None:
+    """mcp-reflect must reference ppds-mcp-server.dll (PPDS.Mcp's AssemblyName)."""
+    assert "ppds-mcp-server.dll" in workflow_text, (
+        "mcp-reflect must use the actual assembly name ppds-mcp-server.dll, "
+        "not PPDS.Mcp.dll"
+    )
+
+
+def test_dry_run_dispatch_preserved(workflow: dict) -> None:
+    """workflow_dispatch with dry_run input must be preserved."""
+    on = workflow.get("on") or workflow.get(True)
+    assert "workflow_dispatch" in on, "workflow_dispatch trigger must be preserved"
+    inputs = on["workflow_dispatch"].get("inputs", {})
+    assert "dry_run" in inputs, "dry_run input must be preserved"

--- a/tests/ci/test_docs_release_workflow.py
+++ b/tests/ci/test_docs_release_workflow.py
@@ -25,7 +25,7 @@ def workflow() -> dict:
     """Parse the workflow YAML once per module."""
     if not WORKFLOW_PATH.exists():
         pytest.fail(f"docs-release.yml not found at {WORKFLOW_PATH}")
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8")) or {}
 
 
 @pytest.fixture(scope="module")
@@ -74,7 +74,8 @@ def test_mcp_assembly_name_is_correct(workflow_text: str) -> None:
 
 def test_dry_run_dispatch_preserved(workflow: dict) -> None:
     """workflow_dispatch with dry_run input must be preserved."""
-    on = workflow.get("on") or workflow.get(True)
-    assert "workflow_dispatch" in on, "workflow_dispatch trigger must be preserved"
-    inputs = on["workflow_dispatch"].get("inputs", {})
+    on_config = workflow.get("on") or workflow.get(True) or {}
+    assert "workflow_dispatch" in on_config, "workflow_dispatch trigger must be preserved"
+    dispatch = on_config.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs", {})
     assert "dry_run" in inputs, "dry_run input must be preserved"


### PR DESCRIPTION
## Summary
- Replace `dotnet build PPDS.sln -o artifacts/bin` with individual project builds (`PPDS.Cli`, `PPDS.Mcp`) to avoid NETSDK1194 warning where test projects race-write `runtimeconfig.json` into the shared output directory
- Fix assembly name references in the workflow (`PPDS.Cli.dll` → `ppds.dll`, `PPDS.Mcp.dll` → `ppds-mcp-server.dll`) to match the actual `AssemblyName` properties in each csproj
- Fix `$(OutputPath)` → `$(TargetDir)` in `PPDS.LiveTests.Fixtures.csproj` CopyToTestData target to prevent missing-separator path concatenation bug (`artifacts/binPPDS.LiveTests.Fixtures.dll`)
- Add CI regression tests guarding against solution-wide `-o` reintroduction

## Test Plan
- [x] New regression tests in `tests/ci/test_docs_release_workflow.py` (5 tests) — all pass
- [x] All 157 CI tests pass
- [x] Full .NET build + unit test suite passes across net8.0/net9.0/net10.0
- [ ] Dry-run validation: `gh workflow run docs-release.yml -f dry_run=true` (post-merge)

## Verification
- [x] /gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)