### PR TITLE
fix(hooks,urls): metadata mutation hook gap and sovereign-cloud URLs (#870, #879)

### DIFF
--- a/.claude/hooks/shakedown-safety.py
+++ b/.claude/hooks/shakedown-safety.py
@@ -495,6 +495,11 @@ def is_mutation(argv: list) -> tuple:
     verb = argv[2].lower()
     rest = argv[3:]
 
+    # 3-level commands: "metadata <noun> <verb>" has the noun at argv[2], verb at argv[3]
+    if sub == "metadata" and verb not in _MUTATION_VERBS and len(argv) >= 4:
+        verb = argv[3].lower()
+        rest = argv[4:]
+
     allowed = _READONLY_SUBCOMMANDS.get(sub)
     if allowed and ("*" in allowed or verb in allowed):
         return False, ""

--- a/src/PPDS.Auth/Cloud/CloudEndpoints.cs
+++ b/src/PPDS.Auth/Cloud/CloudEndpoints.cs
@@ -155,6 +155,42 @@ public static class CloudEndpoints
     }
 
     /// <summary>
+    /// Gets the Power Apps Maker portal base URL for the specified cloud environment.
+    /// </summary>
+    /// <param name="cloud">The cloud environment.</param>
+    /// <returns>The Maker portal base URL (no trailing slash).</returns>
+    public static string GetMakerPortalUrl(CloudEnvironment cloud)
+    {
+        return cloud switch
+        {
+            CloudEnvironment.Public => "https://make.powerapps.com",
+            CloudEnvironment.UsGov => "https://make.gov.powerapps.us",
+            CloudEnvironment.UsGovHigh => "https://make.high.powerapps.us",
+            CloudEnvironment.UsGovDod => "https://make.apps.appsplatform.us",
+            CloudEnvironment.China => "https://make.powerapps.cn",
+            _ => throw new ArgumentOutOfRangeException(nameof(cloud), cloud, "Unknown cloud environment")
+        };
+    }
+
+    /// <summary>
+    /// Gets the Power Automate Maker portal base URL for the specified cloud environment.
+    /// </summary>
+    /// <param name="cloud">The cloud environment.</param>
+    /// <returns>The Flow portal base URL (no trailing slash).</returns>
+    public static string GetFlowPortalUrl(CloudEnvironment cloud)
+    {
+        return cloud switch
+        {
+            CloudEnvironment.Public => "https://make.powerautomate.com",
+            CloudEnvironment.UsGov => "https://make.gov.powerautomate.us",
+            CloudEnvironment.UsGovHigh => "https://make.high.powerautomate.us",
+            CloudEnvironment.UsGovDod => "https://make.flow.appsplatform.us",
+            CloudEnvironment.China => "https://make.powerautomate.cn",
+            _ => throw new ArgumentOutOfRangeException(nameof(cloud), cloud, "Unknown cloud environment")
+        };
+    }
+
+    /// <summary>
     /// Parses a cloud environment from a string value.
     /// </summary>
     /// <param name="value">The string value (case-insensitive).</param>

--- a/src/PPDS.Auth/PublicAPI.Unshipped.txt
+++ b/src/PPDS.Auth/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static PPDS.Auth.Cloud.CloudEndpoints.GetFlowPortalUrl(PPDS.Auth.Cloud.CloudEnvironment cloud) -> string!
+static PPDS.Auth.Cloud.CloudEndpoints.GetMakerPortalUrl(PPDS.Auth.Cloud.CloudEnvironment cloud) -> string!

--- a/src/PPDS.Cli/Commands/EnvironmentVariables/UrlCommand.cs
+++ b/src/PPDS.Cli/Commands/EnvironmentVariables/UrlCommand.cs
@@ -77,7 +77,7 @@ public static class UrlCommand
                 return ExitCodes.NotFoundError;
             }
 
-            var makerUrl = DataverseUrlBuilder.BuildEnvironmentVariableMakerUrl(connectionInfo.EnvironmentUrl, variable.Id);
+            var makerUrl = DataverseUrlBuilder.BuildEnvironmentVariableMakerUrl(connectionInfo.EnvironmentUrl, variable.Id, connectionInfo.Profile.Cloud);
 
             if (globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Commands/Flows/UrlCommand.cs
+++ b/src/PPDS.Cli/Commands/Flows/UrlCommand.cs
@@ -95,7 +95,7 @@ public static class UrlCommand
                 return ExitCodes.ValidationError;
             }
 
-            var makerUrl = DataverseUrlBuilder.BuildFlowUrl(connectionInfo.EnvironmentId, flow.Id);
+            var makerUrl = DataverseUrlBuilder.BuildFlowUrl(connectionInfo.EnvironmentId, flow.Id, connectionInfo.Profile.Cloud);
 
             if (globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Commands/ImportJobs/UrlCommand.cs
+++ b/src/PPDS.Cli/Commands/ImportJobs/UrlCommand.cs
@@ -78,7 +78,7 @@ public static class UrlCommand
                 return ExitCodes.NotFoundError;
             }
 
-            var makerUrl = DataverseUrlBuilder.BuildImportJobMakerUrl(connectionInfo.EnvironmentUrl, importJobId);
+            var makerUrl = DataverseUrlBuilder.BuildImportJobMakerUrl(connectionInfo.EnvironmentUrl, importJobId, connectionInfo.Profile.Cloud);
 
             if (globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Commands/Solutions/GetCommand.cs
+++ b/src/PPDS.Cli/Commands/Solutions/GetCommand.cs
@@ -83,7 +83,7 @@ public static class GetCommand
                 return ExitCodes.NotFoundError;
             }
 
-            var makerUrl = DataverseUrlBuilder.BuildSolutionMakerUrl(connectionInfo.EnvironmentUrl, solution.Id);
+            var makerUrl = DataverseUrlBuilder.BuildSolutionMakerUrl(connectionInfo.EnvironmentUrl, solution.Id, connectionInfo.Profile.Cloud);
 
             if (globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Commands/Solutions/UrlCommand.cs
+++ b/src/PPDS.Cli/Commands/Solutions/UrlCommand.cs
@@ -77,7 +77,7 @@ public static class UrlCommand
                 return ExitCodes.NotFoundError;
             }
 
-            var makerUrl = DataverseUrlBuilder.BuildSolutionMakerUrl(connectionInfo.EnvironmentUrl, solution.Id);
+            var makerUrl = DataverseUrlBuilder.BuildSolutionMakerUrl(connectionInfo.EnvironmentUrl, solution.Id, connectionInfo.Profile.Cloud);
 
             if (globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Infrastructure/DataverseUrlBuilder.cs
+++ b/src/PPDS.Cli/Infrastructure/DataverseUrlBuilder.cs
@@ -1,3 +1,5 @@
+using PPDS.Auth.Cloud;
+
 namespace PPDS.Cli.Infrastructure;
 
 /// <summary>
@@ -36,40 +38,44 @@ public static class DataverseUrlBuilder
     /// Builds a Power Apps Maker portal URL using a Power Platform environment ID directly.
     /// Used when the environment ID is available but the environment URL may not contain org name.
     /// </summary>
-    public static string BuildMakerPortalUrl(string environmentId, string? path = "/solutions")
+    public static string BuildMakerPortalUrl(string environmentId, string? path = "/solutions", CloudEnvironment cloud = CloudEnvironment.Public)
     {
+        var makerBase = CloudEndpoints.GetMakerPortalUrl(cloud);
         var trimmedPath = (path ?? "/solutions").TrimStart('/');
-        return $"https://make.powerapps.com/environments/{environmentId}/{trimmedPath}";
+        return $"{makerBase}/environments/{environmentId}/{trimmedPath}";
     }
 
     /// <summary>
     /// Builds the Power Apps Maker portal URL for a specific solution.
     /// </summary>
-    public static string BuildSolutionMakerUrl(string environmentUrl, Guid solutionId)
+    public static string BuildSolutionMakerUrl(string environmentUrl, Guid solutionId, CloudEnvironment cloud = CloudEnvironment.Public)
     {
+        var makerBase = CloudEndpoints.GetMakerPortalUrl(cloud);
         var uri = new Uri(environmentUrl);
         var orgName = uri.Host.Split('.')[0];
-        return $"https://make.powerapps.com/environments/Default-{orgName}/solutions/{solutionId}";
+        return $"{makerBase}/environments/Default-{orgName}/solutions/{solutionId}";
     }
 
     /// <summary>
     /// Builds the Power Apps Maker portal URL for an environment variable definition.
     /// </summary>
-    public static string BuildEnvironmentVariableMakerUrl(string environmentUrl, Guid definitionId)
+    public static string BuildEnvironmentVariableMakerUrl(string environmentUrl, Guid definitionId, CloudEnvironment cloud = CloudEnvironment.Public)
     {
+        var makerBase = CloudEndpoints.GetMakerPortalUrl(cloud);
         var uri = new Uri(environmentUrl);
         var orgName = uri.Host.Split('.')[0];
-        return $"https://make.powerapps.com/environments/Default-{orgName}/solutions/environmentvariables/{definitionId}";
+        return $"{makerBase}/environments/Default-{orgName}/solutions/environmentvariables/{definitionId}";
     }
 
     /// <summary>
     /// Builds the Power Apps Maker portal URL for an import job.
     /// </summary>
-    public static string BuildImportJobMakerUrl(string environmentUrl, Guid importJobId)
+    public static string BuildImportJobMakerUrl(string environmentUrl, Guid importJobId, CloudEnvironment cloud = CloudEnvironment.Public)
     {
+        var makerBase = CloudEndpoints.GetMakerPortalUrl(cloud);
         var uri = new Uri(environmentUrl);
         var orgName = uri.Host.Split('.')[0];
-        return $"https://make.powerapps.com/environments/Default-{orgName}/solutions/importjob/{importJobId}";
+        return $"{makerBase}/environments/Default-{orgName}/solutions/importjob/{importJobId}";
     }
 
     /// <summary>
@@ -85,8 +91,9 @@ public static class DataverseUrlBuilder
     /// Builds the Power Automate flow details URL.
     /// Note: This takes a Power Platform environment ID (GUID string), not an environment URL.
     /// </summary>
-    public static string BuildFlowUrl(string environmentId, Guid flowId)
+    public static string BuildFlowUrl(string environmentId, Guid flowId, CloudEnvironment cloud = CloudEnvironment.Public)
     {
-        return $"https://make.powerautomate.com/environments/{environmentId}/flows/{flowId}/details";
+        var flowBase = CloudEndpoints.GetFlowPortalUrl(cloud);
+        return $"{flowBase}/environments/{environmentId}/flows/{flowId}/details";
     }
 }

--- a/tests/PPDS.Auth.Tests/Cloud/CloudEndpointsTests.cs
+++ b/tests/PPDS.Auth.Tests/Cloud/CloudEndpointsTests.cs
@@ -204,4 +204,46 @@ public class CloudEndpointsTests
 
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
+
+    [Theory]
+    [InlineData(CloudEnvironment.Public, "https://make.powerapps.com")]
+    [InlineData(CloudEnvironment.UsGov, "https://make.gov.powerapps.us")]
+    [InlineData(CloudEnvironment.UsGovHigh, "https://make.high.powerapps.us")]
+    [InlineData(CloudEnvironment.UsGovDod, "https://make.apps.appsplatform.us")]
+    [InlineData(CloudEnvironment.China, "https://make.powerapps.cn")]
+    public void GetMakerPortalUrl_ReturnsCorrectUrl(CloudEnvironment cloud, string expected)
+    {
+        var result = CloudEndpoints.GetMakerPortalUrl(cloud);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetMakerPortalUrl_InvalidCloud_Throws()
+    {
+        var act = () => CloudEndpoints.GetMakerPortalUrl((CloudEnvironment)999);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Theory]
+    [InlineData(CloudEnvironment.Public, "https://make.powerautomate.com")]
+    [InlineData(CloudEnvironment.UsGov, "https://make.gov.powerautomate.us")]
+    [InlineData(CloudEnvironment.UsGovHigh, "https://make.high.powerautomate.us")]
+    [InlineData(CloudEnvironment.UsGovDod, "https://make.flow.appsplatform.us")]
+    [InlineData(CloudEnvironment.China, "https://make.powerautomate.cn")]
+    public void GetFlowPortalUrl_ReturnsCorrectUrl(CloudEnvironment cloud, string expected)
+    {
+        var result = CloudEndpoints.GetFlowPortalUrl(cloud);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetFlowPortalUrl_InvalidCloud_Throws()
+    {
+        var act = () => CloudEndpoints.GetFlowPortalUrl((CloudEnvironment)999);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
 }

--- a/tests/PPDS.Cli.Tests/Infrastructure/DataverseUrlBuilderTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/DataverseUrlBuilderTests.cs
@@ -1,3 +1,4 @@
+using PPDS.Auth.Cloud;
 using PPDS.Cli.Infrastructure;
 using Xunit;
 
@@ -187,6 +188,74 @@ public class DataverseUrlBuilderTests
         Assert.Equal(
             $"https://make.powerautomate.com/environments/env-id-123/flows/{flowId}/details",
             url);
+    }
+
+    #endregion
+
+    #region Sovereign Cloud Tests
+
+    [Theory]
+    [InlineData(CloudEnvironment.Public, "https://make.powerapps.com/environments/env-123/solutions")]
+    [InlineData(CloudEnvironment.UsGovHigh, "https://make.high.powerapps.us/environments/env-123/solutions")]
+    [InlineData(CloudEnvironment.China, "https://make.powerapps.cn/environments/env-123/solutions")]
+    public void BuildMakerPortalUrl_SovereignCloud_UsesCorrectDomain(
+        CloudEnvironment cloud, string expected)
+    {
+        var url = DataverseUrlBuilder.BuildMakerPortalUrl("env-123", cloud: cloud);
+
+        Assert.Equal(expected, url);
+    }
+
+    [Theory]
+    [InlineData(CloudEnvironment.Public, "https://make.powerapps.com")]
+    [InlineData(CloudEnvironment.UsGovHigh, "https://make.high.powerapps.us")]
+    public void BuildSolutionMakerUrl_SovereignCloud_UsesCorrectDomain(
+        CloudEnvironment cloud, string expectedPrefix)
+    {
+        var solutionId = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var url = DataverseUrlBuilder.BuildSolutionMakerUrl(
+            "https://myorg.crm.dynamics.com", solutionId, cloud);
+
+        Assert.StartsWith(expectedPrefix, url);
+    }
+
+    [Theory]
+    [InlineData(CloudEnvironment.Public, "https://make.powerapps.com")]
+    [InlineData(CloudEnvironment.UsGovDod, "https://make.apps.appsplatform.us")]
+    public void BuildEnvironmentVariableMakerUrl_SovereignCloud_UsesCorrectDomain(
+        CloudEnvironment cloud, string expectedPrefix)
+    {
+        var defId = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var url = DataverseUrlBuilder.BuildEnvironmentVariableMakerUrl(
+            "https://myorg.crm.dynamics.com", defId, cloud);
+
+        Assert.StartsWith(expectedPrefix, url);
+    }
+
+    [Theory]
+    [InlineData(CloudEnvironment.Public, "https://make.powerapps.com")]
+    [InlineData(CloudEnvironment.UsGov, "https://make.gov.powerapps.us")]
+    public void BuildImportJobMakerUrl_SovereignCloud_UsesCorrectDomain(
+        CloudEnvironment cloud, string expectedPrefix)
+    {
+        var jobId = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var url = DataverseUrlBuilder.BuildImportJobMakerUrl(
+            "https://myorg.crm.dynamics.com", jobId, cloud);
+
+        Assert.StartsWith(expectedPrefix, url);
+    }
+
+    [Theory]
+    [InlineData(CloudEnvironment.Public, "https://make.powerautomate.com")]
+    [InlineData(CloudEnvironment.UsGovHigh, "https://make.high.powerautomate.us")]
+    [InlineData(CloudEnvironment.China, "https://make.powerautomate.cn")]
+    public void BuildFlowUrl_SovereignCloud_UsesCorrectDomain(
+        CloudEnvironment cloud, string expectedPrefix)
+    {
+        var flowId = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var url = DataverseUrlBuilder.BuildFlowUrl("env-id-123", flowId, cloud);
+
+        Assert.StartsWith(expectedPrefix, url);
     }
 
     #endregion

--- a/tests/hooks/test_shakedown_safety.py
+++ b/tests/hooks/test_shakedown_safety.py
@@ -894,6 +894,55 @@ class TestIsMutation:
         assert not is_mut
 
 
+class TestMetadataMutations:
+    """#870: 3-level metadata commands (metadata <noun> <verb>) must be detected as mutations."""
+
+    @pytest.mark.parametrize("argv", [
+        ["ppds", "metadata", "table", "create", "--solution", "s", "--name", "t"],
+        ["ppds", "metadata", "table", "update", "--solution", "s", "--entity", "t"],
+        ["ppds", "metadata", "table", "delete", "--solution", "s", "--entity", "t"],
+        ["ppds", "metadata", "column", "create", "--solution", "s", "--entity", "t"],
+        ["ppds", "metadata", "column", "update", "--solution", "s", "--entity", "t"],
+        ["ppds", "metadata", "column", "delete", "--solution", "s", "--entity", "t"],
+        ["ppds", "metadata", "relationship", "create", "--solution", "s"],
+        ["ppds", "metadata", "relationship", "delete", "--solution", "s"],
+        ["ppds", "metadata", "key", "create", "--solution", "s", "--entity", "t"],
+        ["ppds", "metadata", "key", "delete", "--solution", "s", "--entity", "t"],
+        ["ppds", "metadata", "choice", "create", "--solution", "s"],
+        ["ppds", "metadata", "choice", "update", "--solution", "s"],
+        ["ppds", "metadata", "choice", "delete", "--solution", "s"],
+    ])
+    def test_metadata_noun_verb_detected_as_mutation(self, argv):
+        is_mut, reason = hook.is_mutation(argv)
+        assert is_mut, f"argv={argv}: expected mutation but got is_mutation=False"
+        verb = argv[3]
+        assert verb in reason, f"reason should mention '{verb}': {reason}"
+
+    def test_metadata_publish_still_detected(self):
+        is_mut, reason = hook.is_mutation(["ppds", "metadata", "publish"])
+        assert is_mut
+        assert "publish" in reason
+
+    @pytest.mark.parametrize("argv", [
+        ["ppds", "metadata", "entities"],
+        ["ppds", "metadata", "entity", "account"],
+    ])
+    def test_metadata_readonly_not_mutation(self, argv):
+        is_mut, _ = hook.is_mutation(argv)
+        assert not is_mut, f"argv={argv}: should not be a mutation"
+
+    @pytest.mark.parametrize("cmd", [
+        "ppds metadata table create --solution s --name t",
+        "ppds metadata column delete --solution s --entity t --name c",
+        "ppds metadata choice update --solution s --name c",
+    ])
+    def test_metadata_mutations_blocked_during_shakedown(self, fake_profile_dir, cmd):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        r = _run_hook(cmd, env_extra=_shakedown_env(config_dir))
+        assert r.returncode == 2, f"cmd={cmd}: stderr={r.stderr!r}"
+        assert "BLOCKED [shakedown-safety/readonly]" in r.stderr
+
+
 class TestLoadSafetyConfig:
     def test_load_from_settings(self, tmp_path, monkeypatch):
         project = tmp_path / "p"


### PR DESCRIPTION
## Summary
- **#870 (CRITICAL)**: Fix shakedown-safety hook `is_mutation()` to detect 3-level metadata commands (`metadata table create`, `metadata column delete`, etc.) where the verb is at argv[3], not argv[2]. All 18+ metadata mutation commands now correctly blocked during shakedown.
- **#879**: Replace hardcoded `make.powerapps.com` and `make.powerautomate.com` in `DataverseUrlBuilder` with cloud-aware URLs from new `CloudEndpoints.GetMakerPortalUrl()` / `GetFlowPortalUrl()` methods. GovHigh, GovDoD, and China users now get correct Maker portal links.

Closes #870
Closes #879

## Test Plan
- [x] 13 parametrized unit tests for metadata noun+verb mutation detection
- [x] 3 end-to-end subprocess tests for metadata mutations during shakedown
- [x] 2 negative tests (readonly metadata commands not flagged)
- [x] 1 regression test (2-level `metadata publish` still detected)
- [x] 10 sovereign cloud URL tests across 5 DataverseUrlBuilder methods
- [x] 10 CloudEndpoints tests (GetMakerPortalUrl + GetFlowPortalUrl, all 5 clouds)
- [x] Existing 98 hook tests still pass (no regressions)
- [x] All 3324 CLI tests pass across net8.0/net9.0/net10.0

## Verification
- [x] /gates passed (0 errors, 0 test failures)
- [x] /verify completed (surfaces: workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)