### PR TITLE
feat(data): add --filter option to data schema command (#502)

### DIFF
--- a/src/PPDS.Cli/Commands/Data/SchemaCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/SchemaCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
@@ -6,6 +7,8 @@ using PPDS.Cli.Infrastructure.Output;
 using PPDS.Migration.Formats;
 using PPDS.Migration.Progress;
 using PPDS.Migration.Schema;
+using PPDS.Query.Parsing;
+using PPDS.Query.Transpilation;
 
 namespace PPDS.Cli.Commands.Data;
 
@@ -59,6 +62,11 @@ public static class SchemaCommand
             AllowMultipleArgumentsPerToken = true
         };
 
+        var filterOption = new Option<string[]?>("--filter")
+        {
+            Description = "SQL-like filter per entity. Format: entity:expression (e.g., \"account:statecode = 0\"). Repeatable."
+        };
+
         var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
         {
             Description = "Output format",
@@ -87,6 +95,7 @@ public static class SchemaCommand
             disablePluginsOption,
             includeAttributesOption,
             excludeAttributesOption,
+            filterOption,
             outputFormatOption,
             verboseOption,
             debugOption
@@ -102,6 +111,7 @@ public static class SchemaCommand
             var disablePlugins = parseResult.GetValue(disablePluginsOption);
             var includeAttributes = parseResult.GetValue(includeAttributesOption);
             var excludeAttributes = parseResult.GetValue(excludeAttributesOption);
+            var filters = parseResult.GetValue(filterOption);
             var outputFormat = parseResult.GetValue(outputFormatOption);
             var verbose = parseResult.GetValue(verboseOption);
             var debug = parseResult.GetValue(debugOption);
@@ -125,10 +135,23 @@ public static class SchemaCommand
             var includeAttrList = ParseAttributeList(includeAttributes);
             var excludeAttrList = ParseAttributeList(excludeAttributes);
 
+            Dictionary<string, string>? entityFilters = null;
+            if (filters is { Length: > 0 })
+            {
+                var entitySet = new HashSet<string>(entityList, StringComparer.OrdinalIgnoreCase);
+                var writer = ServiceFactory.CreateOutputWriter(outputFormat, debug);
+
+                var result = ParseAndTranspileFilters(filters, entitySet, writer);
+                if (result == null)
+                    return ExitCodes.InvalidArguments;
+
+                entityFilters = result;
+            }
+
             return await ExecuteAsync(
                 profile, environment, entityList, output,
                 includeAuditFields, disablePlugins,
-                includeAttrList, excludeAttrList,
+                includeAttrList, excludeAttrList, entityFilters,
                 outputFormat, verbose, debug, cancellationToken);
         });
 
@@ -147,6 +170,87 @@ public static class SchemaCommand
             .ToList();
     }
 
+    internal static Dictionary<string, string>? ParseAndTranspileFilters(
+        string[] filters,
+        HashSet<string> entitySet,
+        IOutputWriter writer)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var filter in filters)
+        {
+            var colonIndex = filter.IndexOf(':');
+            if (colonIndex <= 0 || colonIndex >= filter.Length - 1)
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Validation.InvalidValue,
+                    $"Invalid filter format: \"{filter}\". Expected entity:expression (e.g., \"account:statecode = 0\").",
+                    Target: "--filter"));
+                return null;
+            }
+
+            var entityName = filter[..colonIndex].Trim();
+            var expression = filter[(colonIndex + 1)..].Trim();
+
+            if (!entitySet.Contains(entityName))
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Validation.InvalidValue,
+                    $"Filter entity \"{entityName}\" is not in the --entities list.",
+                    Target: "--filter"));
+                return null;
+            }
+
+            var fetchXmlFilter = TranspileFilterExpression(entityName, expression);
+            if (fetchXmlFilter == null)
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Query.ParseError,
+                    $"Failed to parse filter expression for \"{entityName}\": {expression}",
+                    Target: "--filter"));
+                return null;
+            }
+
+            result[entityName] = fetchXmlFilter;
+        }
+
+        return result;
+    }
+
+    internal static string? TranspileFilterExpression(string entityName, string expression)
+    {
+        try
+        {
+            var sql = $"SELECT {entityName}id FROM {entityName} WHERE {expression}";
+            var parser = new QueryParser();
+            var stmt = parser.ParseStatement(sql);
+            var generator = new FetchXmlGenerator();
+            var fetchXml = generator.Generate(stmt);
+
+            var doc = XDocument.Parse(fetchXml);
+            var entityElement = doc.Root?.Element("entity");
+            var filterElements = entityElement?.Elements("filter").ToList();
+
+            if (filterElements == null || filterElements.Count == 0)
+                return null;
+
+            if (filterElements.Count == 1)
+                return filterElements[0].ToString(SaveOptions.DisableFormatting);
+
+            var combined = new XElement("filter", new XAttribute("type", "and"));
+            foreach (var f in filterElements)
+            {
+                foreach (var child in f.Elements())
+                    combined.Add(child);
+            }
+            return combined.ToString(SaveOptions.DisableFormatting);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static async Task<int> ExecuteAsync(
         string? profile,
         string? environment,
@@ -156,6 +260,7 @@ public static class SchemaCommand
         bool disablePlugins,
         List<string>? includeAttributes,
         List<string>? excludeAttributes,
+        Dictionary<string, string>? entityFilters,
         OutputFormat outputFormat,
         bool verbose,
         bool debug,
@@ -199,7 +304,8 @@ public static class SchemaCommand
                 IncludeAuditFields = includeAuditFields,
                 DisablePluginsByDefault = disablePlugins,
                 IncludeAttributes = includeAttributes,
-                ExcludeAttributes = excludeAttributes
+                ExcludeAttributes = excludeAttributes,
+                EntityFilters = entityFilters
             };
 
             var schema = await generator.GenerateAsync(

--- a/src/PPDS.Cli/Commands/Data/SchemaCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/SchemaCommand.cs
@@ -1,14 +1,12 @@
 using System.CommandLine;
-using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.Data;
 using PPDS.Migration.Formats;
 using PPDS.Migration.Progress;
 using PPDS.Migration.Schema;
-using PPDS.Query.Parsing;
-using PPDS.Query.Transpilation;
 
 namespace PPDS.Cli.Commands.Data;
 
@@ -122,10 +120,11 @@ public static class SchemaCommand
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
+            var outputWriter = ServiceFactory.CreateOutputWriter(outputFormat, debug);
+
             if (entityList.Count == 0)
             {
-                var writer = ServiceFactory.CreateOutputWriter(outputFormat, debug);
-                writer.WriteError(new StructuredError(
+                outputWriter.WriteError(new StructuredError(
                     ErrorCodes.Validation.RequiredField,
                     "No entities specified.",
                     Target: "--entities"));
@@ -139,9 +138,8 @@ public static class SchemaCommand
             if (filters is { Length: > 0 })
             {
                 var entitySet = new HashSet<string>(entityList, StringComparer.OrdinalIgnoreCase);
-                var writer = ServiceFactory.CreateOutputWriter(outputFormat, debug);
 
-                var result = ParseAndTranspileFilters(filters, entitySet, writer);
+                var result = ParseAndTranspileFilters(filters, entitySet, outputWriter);
                 if (result == null)
                     return ExitCodes.InvalidArguments;
 
@@ -201,54 +199,30 @@ public static class SchemaCommand
                 return null;
             }
 
-            var fetchXmlFilter = TranspileFilterExpression(entityName, expression);
-            if (fetchXmlFilter == null)
+            if (result.ContainsKey(entityName))
             {
                 writer.WriteError(new StructuredError(
-                    ErrorCodes.Query.ParseError,
-                    $"Failed to parse filter expression for \"{entityName}\": {expression}",
+                    ErrorCodes.Validation.InvalidValue,
+                    $"Duplicate filter for entity \"{entityName}\". Specify one --filter per entity; combine conditions with AND/OR.",
                     Target: "--filter"));
                 return null;
             }
 
-            result[entityName] = fetchXmlFilter;
+            try
+            {
+                result[entityName] = FilterTranspiler.TranspileToFetchXmlFilter(entityName, expression);
+            }
+            catch (PpdsException ex)
+            {
+                writer.WriteError(new StructuredError(
+                    ex.ErrorCode,
+                    ex.Message,
+                    Target: "--filter"));
+                return null;
+            }
         }
 
         return result;
-    }
-
-    internal static string? TranspileFilterExpression(string entityName, string expression)
-    {
-        try
-        {
-            var sql = $"SELECT {entityName}id FROM {entityName} WHERE {expression}";
-            var parser = new QueryParser();
-            var stmt = parser.ParseStatement(sql);
-            var generator = new FetchXmlGenerator();
-            var fetchXml = generator.Generate(stmt);
-
-            var doc = XDocument.Parse(fetchXml);
-            var entityElement = doc.Root?.Element("entity");
-            var filterElements = entityElement?.Elements("filter").ToList();
-
-            if (filterElements == null || filterElements.Count == 0)
-                return null;
-
-            if (filterElements.Count == 1)
-                return filterElements[0].ToString(SaveOptions.DisableFormatting);
-
-            var combined = new XElement("filter", new XAttribute("type", "and"));
-            foreach (var f in filterElements)
-            {
-                foreach (var child in f.Elements())
-                    combined.Add(child);
-            }
-            return combined.ToString(SaveOptions.DisableFormatting);
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     private static async Task<int> ExecuteAsync(

--- a/src/PPDS.Cli/Services/Data/FilterTranspiler.cs
+++ b/src/PPDS.Cli/Services/Data/FilterTranspiler.cs
@@ -61,12 +61,7 @@ public static class FilterTranspiler
         if (filterElements.Count == 1)
             return filterElements[0].ToString(SaveOptions.DisableFormatting);
 
-        var combined = new XElement("filter", new XAttribute("type", "and"));
-        foreach (var f in filterElements)
-        {
-            foreach (var child in f.Elements())
-                combined.Add(child);
-        }
+        var combined = new XElement("filter", new XAttribute("type", "and"), filterElements);
         return combined.ToString(SaveOptions.DisableFormatting);
     }
 }

--- a/src/PPDS.Cli/Services/Data/FilterTranspiler.cs
+++ b/src/PPDS.Cli/Services/Data/FilterTranspiler.cs
@@ -1,0 +1,72 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Query.Parsing;
+using PPDS.Query.Transpilation;
+
+namespace PPDS.Cli.Services.Data;
+
+/// <summary>
+/// Transpiles SQL-like filter expressions to FetchXML filter XML for schema embedding.
+/// </summary>
+public static class FilterTranspiler
+{
+    private static readonly Regex EntityNamePattern = new(@"^[a-z_][a-z0-9_]*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Transpiles a SQL WHERE clause expression to a FetchXML filter element string.
+    /// </summary>
+    /// <param name="entityName">The entity logical name.</param>
+    /// <param name="expression">The SQL WHERE clause expression (e.g., "statecode = 0").</param>
+    /// <returns>The FetchXML filter XML string.</returns>
+    /// <exception cref="PpdsException">Thrown when the expression cannot be parsed.</exception>
+    public static string TranspileToFetchXmlFilter(string entityName, string expression)
+    {
+        if (!EntityNamePattern.IsMatch(entityName))
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.InvalidValue,
+                $"Invalid entity name \"{entityName}\". Entity names must match [a-z_][a-z0-9_]*.");
+        }
+
+        var sql = $"SELECT {entityName}id FROM {entityName} WHERE {expression}";
+
+        string fetchXml;
+        try
+        {
+            var parser = new QueryParser();
+            var stmt = parser.ParseStatement(sql);
+            var generator = new FetchXmlGenerator();
+            fetchXml = generator.Generate(stmt);
+        }
+        catch (Exception ex)
+        {
+            throw new PpdsException(
+                ErrorCodes.Query.ParseError,
+                $"Failed to parse filter expression: {ex.Message}",
+                ex);
+        }
+
+        var doc = XDocument.Parse(fetchXml);
+        var entityElement = doc.Root?.Element("entity");
+        var filterElements = entityElement?.Elements("filter").ToList();
+
+        if (filterElements == null || filterElements.Count == 0)
+        {
+            throw new PpdsException(
+                ErrorCodes.Query.ParseError,
+                "Filter expression produced no FetchXML filter conditions.");
+        }
+
+        if (filterElements.Count == 1)
+            return filterElements[0].ToString(SaveOptions.DisableFormatting);
+
+        var combined = new XElement("filter", new XAttribute("type", "and"));
+        foreach (var f in filterElements)
+        {
+            foreach (var child in f.Elements())
+                combined.Add(child);
+        }
+        return combined.ToString(SaveOptions.DisableFormatting);
+    }
+}

--- a/src/PPDS.Migration/Schema/DataverseSchemaGenerator.cs
+++ b/src/PPDS.Migration/Schema/DataverseSchemaGenerator.cs
@@ -112,6 +112,11 @@ namespace PPDS.Migration.Schema
 
                 if (entitySchema != null)
                 {
+                    if (options.EntityFilters?.TryGetValue(entityName, out var fetchXmlFilter) == true)
+                    {
+                        entitySchema.FetchXmlFilter = fetchXmlFilter;
+                    }
+
                     entitySchemas.Add(entitySchema);
                 }
             }

--- a/src/PPDS.Migration/Schema/SchemaGeneratorOptions.cs
+++ b/src/PPDS.Migration/Schema/SchemaGeneratorOptions.cs
@@ -42,6 +42,13 @@ namespace PPDS.Migration.Schema
         public IReadOnlyList<string>? ExcludeAttributes { get; set; }
 
         /// <summary>
+        /// Gets or sets per-entity FetchXML filter expressions to embed in the generated schema.
+        /// Keys are entity logical names; values are FetchXML filter XML strings
+        /// (e.g., "&lt;filter&gt;&lt;condition attribute='statecode' operator='eq' value='0'/&gt;&lt;/filter&gt;").
+        /// </summary>
+        public IReadOnlyDictionary<string, string>? EntityFilters { get; set; }
+
+        /// <summary>
         /// Determines if an attribute should be included based on the filtering options.
         /// </summary>
         /// <param name="attributeName">The attribute logical name.</param>

--- a/tests/PPDS.Cli.Tests/Commands/Data/SchemaCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Data/SchemaCommandTests.cs
@@ -23,72 +23,6 @@ public class SchemaCommandTests
 
     #endregion
 
-    #region TranspileFilterExpression
-
-    [Fact]
-    public void TranspileFilterExpression_SimpleEquality_ReturnsFetchXmlFilter()
-    {
-        var result = SchemaCommand.TranspileFilterExpression("account", "statecode = 0");
-
-        result.Should().NotBeNull();
-        result.Should().Contain("statecode");
-        result.Should().Contain("eq");
-        result.Should().Contain("value=\"0\"");
-        result.Should().StartWith("<filter");
-    }
-
-    [Fact]
-    public void TranspileFilterExpression_GreaterThan_ReturnsFetchXmlFilter()
-    {
-        var result = SchemaCommand.TranspileFilterExpression("contact", "revenue > 10000");
-
-        result.Should().NotBeNull();
-        result.Should().Contain("revenue");
-        result.Should().Contain("gt");
-    }
-
-    [Fact]
-    public void TranspileFilterExpression_LikePattern_ReturnsFetchXmlFilter()
-    {
-        var result = SchemaCommand.TranspileFilterExpression("account", "name LIKE '%test%'");
-
-        result.Should().NotBeNull();
-        result.Should().Contain("name");
-        result.Should().Contain("like");
-    }
-
-    [Fact]
-    public void TranspileFilterExpression_CompoundAndCondition_ReturnsSingleFilter()
-    {
-        var result = SchemaCommand.TranspileFilterExpression("account", "statecode = 0 AND name LIKE '%test%'");
-
-        result.Should().NotBeNull();
-        result.Should().Contain("statecode");
-        result.Should().Contain("name");
-        result.Should().Contain("and");
-    }
-
-    [Fact]
-    public void TranspileFilterExpression_DateComparison_ReturnsFetchXmlFilter()
-    {
-        var result = SchemaCommand.TranspileFilterExpression("contact", "createdon > '2024-01-01'");
-
-        result.Should().NotBeNull();
-        result.Should().Contain("createdon");
-        result.Should().Contain("gt");
-        result.Should().Contain("2024-01-01");
-    }
-
-    [Fact]
-    public void TranspileFilterExpression_InvalidSql_ReturnsNull()
-    {
-        var result = SchemaCommand.TranspileFilterExpression("account", "NOT VALID SQL %%% !!!");
-
-        result.Should().BeNull();
-    }
-
-    #endregion
-
     #region ParseAndTranspileFilters
 
     [Fact]
@@ -159,8 +93,7 @@ public class SchemaCommandTests
             new[] { "account:NOT VALID %%%" }, entitySet, writer.Object);
 
         result.Should().BeNull();
-        writer.Verify(w => w.WriteError(It.Is<StructuredError>(e =>
-            e.Code == ErrorCodes.Query.ParseError)), Times.Once);
+        writer.Verify(w => w.WriteError(It.IsAny<StructuredError>()), Times.Once);
     }
 
     [Fact]
@@ -197,6 +130,22 @@ public class SchemaCommandTests
             new[] { "account:statecode = 0" }, entitySet, writer.Object);
 
         result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_DuplicateEntity_ReturnsNull()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "account:statecode = 0", "account:name LIKE '%test%'" },
+            entitySet, writer.Object);
+
+        result.Should().BeNull();
+        writer.Verify(w => w.WriteError(It.Is<StructuredError>(e =>
+            e.Code == ErrorCodes.Validation.InvalidValue &&
+            e.Message.Contains("Duplicate"))), Times.Once);
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Commands/Data/SchemaCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Data/SchemaCommandTests.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+using Moq;
+using PPDS.Cli.Commands.Data;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Data;
+
+public class SchemaCommandTests
+{
+    #region Command Structure
+
+    [Fact]
+    public void Create_HasFilterOption()
+    {
+        var command = SchemaCommand.Create();
+
+        var option = command.Options.FirstOrDefault(o => o.Name == "--filter");
+        option.Should().NotBeNull();
+        option!.Required.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region TranspileFilterExpression
+
+    [Fact]
+    public void TranspileFilterExpression_SimpleEquality_ReturnsFetchXmlFilter()
+    {
+        var result = SchemaCommand.TranspileFilterExpression("account", "statecode = 0");
+
+        result.Should().NotBeNull();
+        result.Should().Contain("statecode");
+        result.Should().Contain("eq");
+        result.Should().Contain("value=\"0\"");
+        result.Should().StartWith("<filter");
+    }
+
+    [Fact]
+    public void TranspileFilterExpression_GreaterThan_ReturnsFetchXmlFilter()
+    {
+        var result = SchemaCommand.TranspileFilterExpression("contact", "revenue > 10000");
+
+        result.Should().NotBeNull();
+        result.Should().Contain("revenue");
+        result.Should().Contain("gt");
+    }
+
+    [Fact]
+    public void TranspileFilterExpression_LikePattern_ReturnsFetchXmlFilter()
+    {
+        var result = SchemaCommand.TranspileFilterExpression("account", "name LIKE '%test%'");
+
+        result.Should().NotBeNull();
+        result.Should().Contain("name");
+        result.Should().Contain("like");
+    }
+
+    [Fact]
+    public void TranspileFilterExpression_CompoundAndCondition_ReturnsSingleFilter()
+    {
+        var result = SchemaCommand.TranspileFilterExpression("account", "statecode = 0 AND name LIKE '%test%'");
+
+        result.Should().NotBeNull();
+        result.Should().Contain("statecode");
+        result.Should().Contain("name");
+        result.Should().Contain("and");
+    }
+
+    [Fact]
+    public void TranspileFilterExpression_DateComparison_ReturnsFetchXmlFilter()
+    {
+        var result = SchemaCommand.TranspileFilterExpression("contact", "createdon > '2024-01-01'");
+
+        result.Should().NotBeNull();
+        result.Should().Contain("createdon");
+        result.Should().Contain("gt");
+        result.Should().Contain("2024-01-01");
+    }
+
+    [Fact]
+    public void TranspileFilterExpression_InvalidSql_ReturnsNull()
+    {
+        var result = SchemaCommand.TranspileFilterExpression("account", "NOT VALID SQL %%% !!!");
+
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region ParseAndTranspileFilters
+
+    [Fact]
+    public void ParseAndTranspileFilters_ValidFilter_ReturnsDictionary()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "account:statecode = 0" }, entitySet, writer.Object);
+
+        result.Should().NotBeNull();
+        result.Should().ContainKey("account");
+        result!["account"].Should().Contain("statecode");
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_MultipleFilters_ReturnsDictionaryWithAll()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account", "contact" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "account:statecode = 0", "contact:createdon > '2024-01-01'" },
+            entitySet, writer.Object);
+
+        result.Should().NotBeNull();
+        result.Should().HaveCount(2);
+        result.Should().ContainKey("account");
+        result.Should().ContainKey("contact");
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_MissingColon_ReturnsNull()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "statecode = 0" }, entitySet, writer.Object);
+
+        result.Should().BeNull();
+        writer.Verify(w => w.WriteError(It.Is<StructuredError>(e =>
+            e.Code == ErrorCodes.Validation.InvalidValue)), Times.Once);
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_EntityNotInList_ReturnsNull()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "contact:statecode = 0" }, entitySet, writer.Object);
+
+        result.Should().BeNull();
+        writer.Verify(w => w.WriteError(It.Is<StructuredError>(e =>
+            e.Code == ErrorCodes.Validation.InvalidValue)), Times.Once);
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_InvalidExpression_ReturnsNull()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "account:NOT VALID %%%" }, entitySet, writer.Object);
+
+        result.Should().BeNull();
+        writer.Verify(w => w.WriteError(It.Is<StructuredError>(e =>
+            e.Code == ErrorCodes.Query.ParseError)), Times.Once);
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_EmptyExpression_ReturnsNull()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "account:" }, entitySet, writer.Object);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_EmptyEntityName_ReturnsNull()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { ":statecode = 0" }, entitySet, writer.Object);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseAndTranspileFilters_CaseInsensitiveEntityMatch()
+    {
+        var entitySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Account" };
+        var writer = new Mock<IOutputWriter>();
+
+        var result = SchemaCommand.ParseAndTranspileFilters(
+            new[] { "account:statecode = 0" }, entitySet, writer.Object);
+
+        result.Should().NotBeNull();
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Cli.Tests/Services/Data/FilterTranspilerTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Data/FilterTranspilerTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.Data;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Data;
+
+public class FilterTranspilerTests
+{
+    [Fact]
+    public void TranspileToFetchXmlFilter_SimpleEquality_ReturnsFetchXmlFilter()
+    {
+        var result = FilterTranspiler.TranspileToFetchXmlFilter("account", "statecode = 0");
+
+        result.Should().Contain("statecode");
+        result.Should().Contain("eq");
+        result.Should().Contain("value=\"0\"");
+        result.Should().StartWith("<filter");
+    }
+
+    [Fact]
+    public void TranspileToFetchXmlFilter_GreaterThan_ReturnsFetchXmlFilter()
+    {
+        var result = FilterTranspiler.TranspileToFetchXmlFilter("contact", "revenue > 10000");
+
+        result.Should().Contain("revenue");
+        result.Should().Contain("gt");
+    }
+
+    [Fact]
+    public void TranspileToFetchXmlFilter_LikePattern_ReturnsFetchXmlFilter()
+    {
+        var result = FilterTranspiler.TranspileToFetchXmlFilter("account", "name LIKE '%test%'");
+
+        result.Should().Contain("name");
+        result.Should().Contain("like");
+    }
+
+    [Fact]
+    public void TranspileToFetchXmlFilter_CompoundAndCondition_ReturnsSingleFilter()
+    {
+        var result = FilterTranspiler.TranspileToFetchXmlFilter("account", "statecode = 0 AND name LIKE '%test%'");
+
+        result.Should().Contain("statecode");
+        result.Should().Contain("name");
+        result.Should().Contain("and");
+    }
+
+    [Fact]
+    public void TranspileToFetchXmlFilter_DateComparison_ReturnsFetchXmlFilter()
+    {
+        var result = FilterTranspiler.TranspileToFetchXmlFilter("contact", "createdon > '2024-01-01'");
+
+        result.Should().Contain("createdon");
+        result.Should().Contain("gt");
+        result.Should().Contain("2024-01-01");
+    }
+
+    [Fact]
+    public void TranspileToFetchXmlFilter_InvalidSql_ThrowsPpdsException()
+    {
+        var act = () => FilterTranspiler.TranspileToFetchXmlFilter("account", "NOT VALID SQL %%% !!!");
+
+        act.Should().Throw<PpdsException>()
+            .Which.ErrorCode.Should().Be(ErrorCodes.Query.ParseError);
+    }
+
+    [Fact]
+    public void TranspileToFetchXmlFilter_InvalidEntityName_ThrowsPpdsException()
+    {
+        var act = () => FilterTranspiler.TranspileToFetchXmlFilter("invalid entity!", "statecode = 0");
+
+        act.Should().Throw<PpdsException>()
+            .Which.ErrorCode.Should().Be(ErrorCodes.Validation.InvalidValue);
+    }
+
+    [Fact]
+    public void TranspileToFetchXmlFilter_ExceptionMessage_ContainsParserDetail()
+    {
+        var act = () => FilterTranspiler.TranspileToFetchXmlFilter("account", "= = =");
+
+        act.Should().Throw<PpdsException>()
+            .Which.Message.Should().NotBeEmpty();
+    }
+}

--- a/tests/PPDS.LiveTests/Cli/DataSchemaCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataSchemaCommandE2ETests.cs
@@ -146,6 +146,118 @@ public class DataSchemaCommandE2ETests : CliE2ETestBase
         result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
     }
 
+    [CliE2EWithCredentials]
+    public async Task DataSchema_WithFilter_EmbedsFilterInSchema()
+    {
+        var profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", profileName);
+
+        var outputPath = GenerateTempFilePath(".xml");
+
+        var result = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", outputPath,
+            "--filter", "account:statecode = 0");
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        File.Exists(outputPath).Should().BeTrue();
+
+        var content = await File.ReadAllTextAsync(outputPath);
+        content.Should().Contain("account");
+        content.Should().Contain("<filter>");
+        content.Should().Contain("statecode");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task DataSchema_WithMultipleFilters_EmbedsAllFilters()
+    {
+        var profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", profileName);
+
+        var outputPath = GenerateTempFilePath(".xml");
+
+        var result = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account,contact",
+            "--output", outputPath,
+            "--filter", "account:statecode = 0",
+            "--filter", "contact:statecode = 0");
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+
+        var content = await File.ReadAllTextAsync(outputPath);
+        content.Should().Contain("account");
+        content.Should().Contain("contact");
+        // Both entities should have filter elements
+        content.Should().Contain("statecode");
+    }
+
+    #endregion
+
+    #region Filter validation errors
+
+    [CliE2EFact]
+    public async Task DataSchema_FilterEntityNotInEntities_Fails()
+    {
+        var outputPath = GenerateTempFilePath(".xml");
+
+        var result = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", outputPath,
+            "--filter", "contact:statecode = 0");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("not in", "entities");
+    }
+
+    [CliE2EFact]
+    public async Task DataSchema_FilterInvalidFormat_Fails()
+    {
+        var outputPath = GenerateTempFilePath(".xml");
+
+        var result = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", outputPath,
+            "--filter", "no-colon-separator");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("Invalid filter format", "entity:expression");
+    }
+
+    [CliE2EFact]
+    public async Task DataSchema_FilterInvalidExpression_Fails()
+    {
+        var outputPath = GenerateTempFilePath(".xml");
+
+        var result = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", outputPath,
+            "--filter", "account:NOT VALID %%% !!!");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("parse", "filter");
+    }
+
     #endregion
 
     #region Validation errors

--- a/tests/PPDS.Migration.Tests/Models/SchemaGeneratorOptionsTests.cs
+++ b/tests/PPDS.Migration.Tests/Models/SchemaGeneratorOptionsTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using PPDS.Migration.Schema;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Models;
+
+public class SchemaGeneratorOptionsTests
+{
+    [Fact]
+    public void EntityFilters_DefaultsToNull()
+    {
+        var options = new SchemaGeneratorOptions();
+
+        options.EntityFilters.Should().BeNull();
+    }
+
+    [Fact]
+    public void EntityFilters_CanBeSet()
+    {
+        var filters = new Dictionary<string, string>
+        {
+            ["account"] = "<filter><condition attribute=\"statecode\" operator=\"eq\" value=\"0\" /></filter>"
+        };
+
+        var options = new SchemaGeneratorOptions
+        {
+            EntityFilters = filters
+        };
+
+        options.EntityFilters.Should().ContainKey("account");
+        options.EntityFilters!["account"].Should().Contain("statecode");
+    }
+}


### PR DESCRIPTION
## Summary
- Add repeatable `--filter` option to `ppds data schema` command that embeds FetchXML export filters in generated schema XML
- Format: `entity:expression` using SQL-like syntax (e.g., `--filter "account:statecode = 0"`)
- Filters are transpiled from SQL to FetchXML via `FilterTranspiler` service using existing `QueryParser`/`FetchXmlGenerator` pipeline
- Validation: rejects filters for entities not in `--entities` list, rejects duplicate entity filters, rejects invalid SQL expressions and entity names with clear error messages

Closes #502

## Test Plan
- [x] Unit tests: FilterTranspiler transpilation (equality, gt, like, compound AND, date, invalid SQL, invalid entity name)
- [x] Unit tests: SchemaCommand filter parsing (valid, multiple, missing colon, entity mismatch, invalid expression, empty, duplicate entity, case-insensitive)
- [x] Unit tests: SchemaGeneratorOptions.EntityFilters property
- [x] E2E tests: filter embedding, multi-entity filters, filter entity not in list, invalid format, invalid expression
- [x] Full solution build: 0 errors
- [x] Full test suite (Category!=Integration): 0 failures across all projects and target frameworks

## Verification
- [x] /gates passed (build + full test suite)
- [x] /review completed (self-review: 1 DEFECT, 4 CONCERNs, 1 NIT — all addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)