### PR TITLE
feat(webresources): pull and push CLI commands with hash tracking

### DIFF
--- a/specs/web-resources.md
+++ b/specs/web-resources.md
@@ -363,28 +363,28 @@ Upload modified web resources from a local folder back to Dataverse with conflic
 | AC-WR-31 | CLI `url` generates Maker portal URL, outputs to stdout | TBD | 🔲 |
 | AC-WR-32 | Name resolution: GUID → exact name → partial match; error on ambiguity for get/url | TBD | 🔲 |
 | AC-WR-33 | CLI `webresources publish` is alias for `ppds publish --type webresource` | TBD | 🔲 |
-| AC-WR-34 | `pull` downloads web resources to target folder preserving hierarchical path structure | `WebResourceSyncServiceTests.PullCreatesDirectoryStructure` | 🔲 |
-| AC-WR-35 | `pull` creates `.ppds/webresources.json` tracking file with version, environmentUrl, solution, resources | `WebResourceSyncServiceTests.PullCreatesTrackingFile` | 🔲 |
-| AC-WR-36 | Tracking file records modifiedOn timestamp and SHA256 hash per resource | `WebResourceTrackingFileTests.TrackingFileContainsHashAndTimestamp` | 🔲 |
-| AC-WR-37 | `pull --strip-prefix` removes publisher prefix from local file paths | `WebResourceSyncServiceTests.StripPrefixRemovesPublisherPrefix` | 🔲 |
-| AC-WR-38 | `pull` downloads content in parallel with progress reporting via IProgressReporter | `WebResourceSyncServiceTests.PullDownloadsInParallel` | 🔲 |
-| AC-WR-39 | `pull` without `--force` warns and skips files with local modifications (hash mismatch) | `WebResourceSyncServiceTests.PullSkipsLocallyModifiedFiles` | 🔲 |
-| AC-WR-40 | `pull --force` overwrites locally modified files | `WebResourceSyncServiceTests.PullForceOverwritesModifiedFiles` | 🔲 |
-| AC-WR-41 | `pull` supports `--solution`, `--type`, `--name` filters (filtering in sync service per A1) | `WebResourceSyncServiceTests.PullFiltersResources` | 🔲 |
-| AC-WR-42 | `push` reads `.ppds/webresources.json` and errors if missing | `PushCommandTests.PushErrorsOnMissingTrackingFile` | 🔲 |
-| AC-WR-43 | `push` detects locally modified files by comparing SHA256 hash, skips unchanged | `WebResourceSyncServiceTests.PushSkipsUnchangedFiles` | 🔲 |
-| AC-WR-44 | `push` detects server conflicts by comparing modifiedOn, exits PreconditionFailed (10) | `PushCommandTests.PushConflictReturnsExitCode10` | 🔲 |
-| AC-WR-45 | `push --force` skips conflict detection and uploads regardless | `WebResourceSyncServiceTests.PushForceSkipsConflictCheck` | 🔲 |
-| AC-WR-46 | `push --dry-run` reports what would be pushed without making changes | `WebResourceSyncServiceTests.PushDryRunNoMutation` | 🔲 |
-| AC-WR-47 | `push --publish` publishes only successfully uploaded resource IDs | `WebResourceSyncServiceTests.PushWithPublishCallsPublishAsync` | 🔲 |
-| AC-WR-48 | `push` updates tracking file after successful upload (new modifiedOn, new hash) | `WebResourceSyncServiceTests.PushUpdatesTrackingFile` | 🔲 |
-| AC-WR-49 | Pull/push business logic lives in `IWebResourceSyncService` (Constitution A1), including filtering | `WebResourceSyncServiceTests.*` | 🔲 |
-| AC-WR-50 | Tracking file keyed by Dataverse resource name, supports round-trip pull→edit→push | `WebResourceSyncServiceTests.RoundTripPullEditPush` | 🔲 |
-| AC-WR-51 | `pull` rejects resource names with path traversal segments that escape target folder | `WebResourceSyncServiceTests.PullRejectsPathTraversal` | 🔲 |
-| AC-WR-52 | `push` validates environment URL matches tracking file, errors on mismatch unless `--force` | `PushCommandTests.PushErrorsOnEnvironmentMismatch` | 🔲 |
-| AC-WR-53 | `push` skips binary types (only uploads text types) with warning | `WebResourceSyncServiceTests.PushSkipsBinaryTypes` | 🔲 |
-| AC-WR-54 | `push` warns and skips tracked files that are missing from disk | `WebResourceSyncServiceTests.PushSkipsDeletedFiles` | 🔲 |
-| AC-WR-55 | `pull` merges tracking file: skipped resources retain prior entries, removed resources are pruned | `WebResourceSyncServiceTests.PullMergesTrackingFile` | 🔲 |
+| AC-WR-34 | `pull` downloads web resources to target folder preserving hierarchical path structure | `WebResourceSyncServiceTests.PullCreatesDirectoryStructure` | ✅ |
+| AC-WR-35 | `pull` creates `.ppds/webresources.json` tracking file with version, environmentUrl, solution, resources | `WebResourceSyncServiceTests.PullCreatesTrackingFile` | ✅ |
+| AC-WR-36 | Tracking file records modifiedOn timestamp and SHA256 hash per resource | `WebResourceTrackingFileTests.TrackingFileContainsHashAndTimestamp` | ✅ |
+| AC-WR-37 | `pull --strip-prefix` removes publisher prefix from local file paths | `WebResourceSyncServiceTests.StripPrefixRemovesPublisherPrefix` | ✅ |
+| AC-WR-38 | `pull` downloads content in parallel with progress reporting via IProgressReporter | `WebResourceSyncServiceTests.PullDownloadsInParallel` | ✅ |
+| AC-WR-39 | `pull` without `--force` warns and skips files with local modifications (hash mismatch) | `WebResourceSyncServiceTests.PullSkipsLocallyModifiedFiles` | ✅ |
+| AC-WR-40 | `pull --force` overwrites locally modified files | `WebResourceSyncServiceTests.PullForceOverwritesModifiedFiles` | ✅ |
+| AC-WR-41 | `pull` supports `--solution`, `--type`, `--name` filters (filtering in sync service per A1) | `WebResourceSyncServiceTests.PullFiltersResources` | ✅ |
+| AC-WR-42 | `push` reads `.ppds/webresources.json` and errors if missing | `WebResourceSyncServiceTests.PushErrorsOnMissingTrackingFile` | ✅ |
+| AC-WR-43 | `push` detects locally modified files by comparing SHA256 hash, skips unchanged | `WebResourceSyncServiceTests.PushSkipsUnchangedFiles` | ✅ |
+| AC-WR-44 | `push` detects server conflicts by comparing modifiedOn, exits PreconditionFailed (10) | `WebResourceSyncServiceTests.PushDetectsServerConflict` + `PushCommandTests.PushConflictReturnsExitCode10` | ✅ |
+| AC-WR-45 | `push --force` skips conflict detection and uploads regardless | `WebResourceSyncServiceTests.PushForceSkipsConflictCheck` | ✅ |
+| AC-WR-46 | `push --dry-run` reports what would be pushed without making changes | `WebResourceSyncServiceTests.PushDryRunNoMutation` | ✅ |
+| AC-WR-47 | `push --publish` publishes only successfully uploaded resource IDs | `WebResourceSyncServiceTests.PushWithPublishCallsPublishAsync` | ✅ |
+| AC-WR-48 | `push` updates tracking file after successful upload (new modifiedOn, new hash) | `WebResourceSyncServiceTests.PushUpdatesTrackingFile` | ✅ |
+| AC-WR-49 | Pull/push business logic lives in `IWebResourceSyncService` (Constitution A1), including filtering | `WebResourceSyncServiceTests.*` | ✅ |
+| AC-WR-50 | Tracking file keyed by Dataverse resource name, supports round-trip pull→edit→push | `WebResourceSyncServiceTests.RoundTripPullEditPush` | ✅ |
+| AC-WR-51 | `pull` rejects resource names with path traversal segments that escape target folder | `WebResourceSyncServiceTests.PullRejectsPathTraversal` | ✅ |
+| AC-WR-52 | `push` validates environment URL matches tracking file, errors on mismatch unless `--force` | `WebResourceSyncServiceTests.PushErrorsOnEnvironmentMismatch_WhenNotForced` | ✅ |
+| AC-WR-53 | `push` skips binary types (only uploads text types) with warning | `WebResourceSyncServiceTests.PushSkipsBinaryTypes` | ✅ |
+| AC-WR-54 | `push` warns and skips tracked files that are missing from disk | `WebResourceSyncServiceTests.PushSkipsDeletedFiles` | ✅ |
+| AC-WR-55 | `pull` merges tracking file: skipped resources retain prior entries, removed resources are pruned | `WebResourceSyncServiceTests.PullMergesTrackingFile` | ✅ |
 
 ---
 

--- a/specs/web-resources.md
+++ b/specs/web-resources.md
@@ -369,7 +369,7 @@ Upload modified web resources from a local folder back to Dataverse with conflic
 | AC-WR-38 | `pull` downloads content in parallel with progress reporting via IProgressReporter | `WebResourceSyncServiceTests.PullDownloadsInParallel` | ✅ |
 | AC-WR-39 | `pull` without `--force` warns and skips files with local modifications (hash mismatch) | `WebResourceSyncServiceTests.PullSkipsLocallyModifiedFiles` | ✅ |
 | AC-WR-40 | `pull --force` overwrites locally modified files | `WebResourceSyncServiceTests.PullForceOverwritesModifiedFiles` | ✅ |
-| AC-WR-41 | `pull` supports `--solution`, `--type`, `--name` filters (filtering in sync service per A1) | `WebResourceSyncServiceTests.PullFiltersResources` | ✅ |
+| AC-WR-41 | `pull` supports `--solution`, `--type`, `--name` filters (filtering in sync service per A1) | `WebResourceSyncServiceTests.PullFiltersByTypeCode` + `PullFiltersByNamePattern` | ✅ |
 | AC-WR-42 | `push` reads `.ppds/webresources.json` and errors if missing | `WebResourceSyncServiceTests.PushErrorsOnMissingTrackingFile` | ✅ |
 | AC-WR-43 | `push` detects locally modified files by comparing SHA256 hash, skips unchanged | `WebResourceSyncServiceTests.PushSkipsUnchangedFiles` | ✅ |
 | AC-WR-44 | `push` detects server conflicts by comparing modifiedOn, exits PreconditionFailed (10) | `WebResourceSyncServiceTests.PushDetectsServerConflict` + `PushCommandTests.PushConflictReturnsExitCode10` | ✅ |

--- a/specs/web-resources.md
+++ b/specs/web-resources.md
@@ -1,15 +1,15 @@
 # Web Resources
 
-**Status:** Implemented
-**Last Updated:** 2026-03-23
-**Code:** [src/PPDS.Dataverse/Services/IWebResourceService.cs](../src/PPDS.Dataverse/Services/IWebResourceService.cs) | [src/PPDS.Extension/src/panels/WebResourcesPanel.ts](../src/PPDS.Extension/src/panels/WebResourcesPanel.ts) | [src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs](../src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs) | [src/PPDS.Cli/Commands/WebResources/](../src/PPDS.Cli/Commands/WebResources/)
+**Status:** Implemented (pull/push: Draft)
+**Last Updated:** 2026-04-25
+**Code:** [src/PPDS.Dataverse/Services/IWebResourceService.cs](../src/PPDS.Dataverse/Services/IWebResourceService.cs) | [src/PPDS.Extension/src/panels/WebResourcesPanel.ts](../src/PPDS.Extension/src/panels/WebResourcesPanel.ts) | [src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs](../src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs) | [src/PPDS.Cli/Commands/WebResources/](../src/PPDS.Cli/Commands/WebResources/) | [src/PPDS.Cli/Services/WebResources/IWebResourceSyncService.cs](../src/PPDS.Cli/Services/WebResources/IWebResourceSyncService.cs)
 **Surfaces:** CLI, TUI, Extension, MCP
 
 ---
 
 ## Overview
 
-Browse, view, edit, and publish web resources. Features a FileSystemProvider for in-editor editing with auto-publish notification, conflict detection, and unpublished change detection. The most complex panel at the VS Code layer due to the full save-conflict-diff-resolve-publish workflow.
+Browse, view, edit, and publish web resources. Features a FileSystemProvider for in-editor editing with auto-publish notification, conflict detection, and unpublished change detection. Pull/push workflow enables batch download to a local folder with hash tracking and batch upload with server conflict detection. The most complex panel at the VS Code layer due to the full save-conflict-diff-resolve-publish workflow.
 
 ### Goals
 
@@ -17,12 +17,13 @@ Browse, view, edit, and publish web resources. Features a FileSystemProvider for
 - **Unpublished change detection:** Detect and surface differences between published and unpublished web resource content
 - **Publish coordination:** Prevent concurrent publish operations per environment via semaphore
 - **Multi-surface consistency:** Same data available via VS Code, TUI, MCP, and CLI (Constitution A1, A2)
+- **Pull/push workflow:** Download web resources to local folder with tracking, push back with conflict detection (#161, #162)
 
 ### Non-Goals
 
 - Web resource creation (managed through solutions)
 - Binary content editing (PNG, JPG, GIF, ICO, XAP are view-only)
-- Bulk import/export of web resources (deployment pipeline concern)
+- CI/CD deployment pipeline automation (pull/push is for developer workflow, not automated deployment)
 
 ---
 
@@ -78,6 +79,10 @@ Browse, view, edit, and publish web resources. Features a FileSystemProvider for
 | `WebResourcesListTool.cs` | MCP tool — web resource listing with type and metadata |
 | `WebResourcesGetTool.cs` | MCP tool — full detail with decoded content for text types |
 | `WebResourcesPublishTool.cs` | MCP tool — publish result |
+| `IWebResourceSyncService` | Application Service — pull (batch download + tracking), push (conflict check + batch upload) |
+| `WebResourceTrackingFile` | Model — `.ppds/webresources.json` serialization, hash computation, read/write |
+| `PullCommand.cs` | CLI command — `ppds webresources pull <folder>` |
+| `PushCommand.cs` | CLI command — `ppds webresources push <path>` |
 
 ### Dependencies
 
@@ -160,6 +165,118 @@ Get the Maker portal URL for a web resource. Follows existing `UrlCommand` patte
 **`ppds webresources publish <name|id>... [--solution <name>]`**
 
 Alias for `ppds publish --type webresource`. Auto-injects `--type webresource`. See [publish.md](./publish.md).
+
+#### Pull/Push Workflow
+
+##### Sync Service
+
+`IWebResourceSyncService` in `src/PPDS.Cli/Services/WebResources/` — orchestrates pull and push using `IWebResourceService` for Dataverse operations and manages the local tracking file. Accepts `IProgressReporter` (Constitution A3). CancellationToken threaded through all parallel operations (Constitution R2).
+
+All filtering (solution, type codes, name pattern) lives in the sync service, not in CLI command handlers (Constitution A1). The sync service calls `IWebResourceService.ListAsync` then applies type-code and name-pattern filters client-side (same logic currently in `ListCommand.cs`, moved to service layer).
+
+| Method | Purpose |
+|--------|---------|
+| `PullAsync(options, progress, ct)` | List → filter → parallel download → write files → write tracking file |
+| `PushAsync(options, progress, ct)` | Read tracking → detect local changes → conflict check → parallel upload → update tracking |
+
+Progress is reported per-resource from the sync service orchestration level (not from individual `IWebResourceService` calls).
+
+##### Tracking File
+
+Path: `<folder>/.ppds/webresources.json` — co-located with pulled files. One folder = one pull context (typically one solution). Multi-solution support is achieved by pulling to separate folders.
+
+```json
+{
+  "version": 1,
+  "environmentUrl": "https://org.crm.dynamics.com",
+  "solution": "core_solution",
+  "stripPrefix": true,
+  "pulledAt": "2026-04-25T10:30:00Z",
+  "resources": {
+    "new_/scripts/app.js": {
+      "id": "a1b2c3d4-...",
+      "modifiedOn": "2026-04-20T14:22:00Z",
+      "hash": "sha256:e3b0c44298fc...",
+      "localPath": "scripts/app.js",
+      "webResourceType": 3
+    }
+  }
+}
+```
+
+Fields:
+- **version** — schema version for forward compatibility
+- **environmentUrl** — the environment pulled from (used by push to validate target)
+- **solution** — solution filter used during pull (null if unfiltered)
+- **stripPrefix** — whether publisher prefix was stripped from local paths
+- **pulledAt** — ISO 8601 timestamp of the pull operation
+- **resources** — keyed by Dataverse web resource name (canonical key)
+  - **id** — web resource GUID
+  - **modifiedOn** — server modifiedOn at pull time (conflict detection baseline)
+  - **hash** — SHA256 of local file content at pull time (local change detection)
+  - **localPath** — relative path from folder root (may differ from name if prefix stripped)
+  - **webResourceType** — type code (needed to map local file back to Dataverse on push)
+
+##### Pull Command
+
+**`ppds webresources pull <folder> [--solution <name>] [--type <type>] [--name <pattern>] [--strip-prefix] [--force]`**
+
+Download web resources from Dataverse to a local folder with tracking metadata.
+
+**Arguments:**
+- `<folder>` — target directory (created if not exists)
+
+**Options:**
+- `--solution <name>` — filter by solution unique name
+- `--type <type>` — filter by type (same shortcuts as `list`: text, image, js, css, etc.)
+- `--name <pattern>` — filter by partial name match
+- `--strip-prefix` — remove publisher prefix from local file paths (e.g., `new_/scripts/app.js` → `scripts/app.js`)
+- `--force` — overwrite local files even if they have uncommitted changes (local hash differs from tracked hash)
+
+**Flow:**
+1. List web resources with solution/type/name filters (filtering in sync service per A1)
+2. **Path validation:** For each resource, resolve the local file path and verify it is a descendant of `<folder>`. Reject any resource whose name contains path traversal segments (`../`) that would escape the target directory — log warning and skip.
+3. If tracking file exists and `--force` not set, check for local modifications (hash mismatch). Warn and skip modified files.
+4. Download text content in parallel with CancellationToken threading (R2). Binary types are recorded in the tracking file (metadata only) but no content file is written — `GetContentAsync` returns null for binary types. Push skips binary types.
+5. Write files to folder preserving hierarchical path structure
+6. **Merge tracking file:** Write/update `.ppds/webresources.json` — new and updated resources get fresh entries (modifiedOn + SHA256 hash), skipped resources retain their prior entries, resources no longer returned by the server query are removed.
+
+**Output (text mode):** Progress to stderr, summary line: "Pulled N web resources to <folder> (M new, K updated, J skipped)"
+**Output (JSON mode):** `{ pulled: [...], skipped: [...], errors: [...] }`
+
+**Exit codes:** 0 = success, 2 = failure
+
+##### Push Command
+
+**`ppds webresources push <path> [--solution <name>] [--force] [--dry-run] [--publish]`**
+
+Upload modified web resources from a local folder back to Dataverse with conflict detection.
+
+**Arguments:**
+- `<path>` — folder containing pulled web resources (must have `.ppds/webresources.json`)
+
+**Options:**
+- `--solution <name>` — override solution scope for `--publish` (default: solution from tracking file). Does not affect content upload — `UpdateContentAsync` is solution-independent.
+- `--force` — skip conflict detection (push even if server has changed) and skip environment URL validation
+- `--dry-run` — preview what would be pushed without making changes (per dry-run convention)
+- `--publish` — publish all successfully pushed web resources after upload
+
+**Flow:**
+1. Read `.ppds/webresources.json` — error if missing. **Environment validation:** verify current connection's environment URL matches tracking file's `environmentUrl`. Error if mismatch unless `--force`.
+2. For each tracked resource: if local file is missing from disk, warn and skip (does not delete from server). If resource is a binary type (`IsTextType` = false), skip (binary files are pulled for reference only). Otherwise compute local file SHA256. If hash matches tracked hash, skip (no local changes).
+3. For each locally modified text resource, query server `modifiedOn` in parallel with CancellationToken threading (R2).
+4. **Conflict detection:** If server modifiedOn differs from tracked modifiedOn and `--force` not set, the entire push is blocked — list all conflicting resources to stderr, exit code 10 (`PreconditionFailed`). Suggest: "Run `ppds webresources pull <path>` to fetch latest changes." All-or-nothing: partial push is not supported to avoid ambiguous state.
+5. If `--dry-run`: report what would be pushed (resource names, change summary), then exit 0.
+6. Upload modified content in parallel via `UpdateContentAsync`. On cancellation, in-flight uploads are cancelled and tracking file is not updated for incomplete uploads.
+7. If `--publish`: publish only the IDs of resources successfully uploaded in step 6, via `PublishAsync`.
+8. Update tracking file: for each successfully uploaded resource, record new modifiedOn from server + new SHA256 hash of the uploaded content.
+
+**Conflict detection limitation:** The modifiedOn check is best-effort — a TOCTOU window exists between step 3 (query) and step 6 (upload). The Dataverse `Update` API does not support optimistic concurrency tokens for web resource content. For the developer workflow use case, the modifiedOn pre-check catches the common case (someone else edited while you were working). True concurrent-edit races are rare and acceptable.
+
+**Output (text mode):** Progress to stderr, summary: "Pushed N web resources (M conflicts detected)" or "Dry run: would push N web resources"
+**Output (JSON mode):** `{ pushed: [...], conflicts: [...], skipped: [...] }`
+
+**Exit codes:** 0 = success, 10 = conflict (PreconditionFailed), 2 = failure
 
 ### Extension Surface
 
@@ -246,6 +363,28 @@ Alias for `ppds publish --type webresource`. Auto-injects `--type webresource`. 
 | AC-WR-31 | CLI `url` generates Maker portal URL, outputs to stdout | TBD | 🔲 |
 | AC-WR-32 | Name resolution: GUID → exact name → partial match; error on ambiguity for get/url | TBD | 🔲 |
 | AC-WR-33 | CLI `webresources publish` is alias for `ppds publish --type webresource` | TBD | 🔲 |
+| AC-WR-34 | `pull` downloads web resources to target folder preserving hierarchical path structure | `WebResourceSyncServiceTests.PullCreatesDirectoryStructure` | 🔲 |
+| AC-WR-35 | `pull` creates `.ppds/webresources.json` tracking file with version, environmentUrl, solution, resources | `WebResourceSyncServiceTests.PullCreatesTrackingFile` | 🔲 |
+| AC-WR-36 | Tracking file records modifiedOn timestamp and SHA256 hash per resource | `WebResourceTrackingFileTests.TrackingFileContainsHashAndTimestamp` | 🔲 |
+| AC-WR-37 | `pull --strip-prefix` removes publisher prefix from local file paths | `WebResourceSyncServiceTests.StripPrefixRemovesPublisherPrefix` | 🔲 |
+| AC-WR-38 | `pull` downloads content in parallel with progress reporting via IProgressReporter | `WebResourceSyncServiceTests.PullDownloadsInParallel` | 🔲 |
+| AC-WR-39 | `pull` without `--force` warns and skips files with local modifications (hash mismatch) | `WebResourceSyncServiceTests.PullSkipsLocallyModifiedFiles` | 🔲 |
+| AC-WR-40 | `pull --force` overwrites locally modified files | `WebResourceSyncServiceTests.PullForceOverwritesModifiedFiles` | 🔲 |
+| AC-WR-41 | `pull` supports `--solution`, `--type`, `--name` filters (filtering in sync service per A1) | `WebResourceSyncServiceTests.PullFiltersResources` | 🔲 |
+| AC-WR-42 | `push` reads `.ppds/webresources.json` and errors if missing | `PushCommandTests.PushErrorsOnMissingTrackingFile` | 🔲 |
+| AC-WR-43 | `push` detects locally modified files by comparing SHA256 hash, skips unchanged | `WebResourceSyncServiceTests.PushSkipsUnchangedFiles` | 🔲 |
+| AC-WR-44 | `push` detects server conflicts by comparing modifiedOn, exits PreconditionFailed (10) | `PushCommandTests.PushConflictReturnsExitCode10` | 🔲 |
+| AC-WR-45 | `push --force` skips conflict detection and uploads regardless | `WebResourceSyncServiceTests.PushForceSkipsConflictCheck` | 🔲 |
+| AC-WR-46 | `push --dry-run` reports what would be pushed without making changes | `WebResourceSyncServiceTests.PushDryRunNoMutation` | 🔲 |
+| AC-WR-47 | `push --publish` publishes only successfully uploaded resource IDs | `WebResourceSyncServiceTests.PushWithPublishCallsPublishAsync` | 🔲 |
+| AC-WR-48 | `push` updates tracking file after successful upload (new modifiedOn, new hash) | `WebResourceSyncServiceTests.PushUpdatesTrackingFile` | 🔲 |
+| AC-WR-49 | Pull/push business logic lives in `IWebResourceSyncService` (Constitution A1), including filtering | `WebResourceSyncServiceTests.*` | 🔲 |
+| AC-WR-50 | Tracking file keyed by Dataverse resource name, supports round-trip pull→edit→push | `WebResourceSyncServiceTests.RoundTripPullEditPush` | 🔲 |
+| AC-WR-51 | `pull` rejects resource names with path traversal segments that escape target folder | `WebResourceSyncServiceTests.PullRejectsPathTraversal` | 🔲 |
+| AC-WR-52 | `push` validates environment URL matches tracking file, errors on mismatch unless `--force` | `PushCommandTests.PushErrorsOnEnvironmentMismatch` | 🔲 |
+| AC-WR-53 | `push` skips binary types (only uploads text types) with warning | `WebResourceSyncServiceTests.PushSkipsBinaryTypes` | 🔲 |
+| AC-WR-54 | `push` warns and skips tracked files that are missing from disk | `WebResourceSyncServiceTests.PushSkipsDeletedFiles` | 🔲 |
+| AC-WR-55 | `pull` merges tracking file: skipped resources retain prior entries, removed resources are pruned | `WebResourceSyncServiceTests.PullMergesTrackingFile` | 🔲 |
 
 ---
 
@@ -283,12 +422,41 @@ Alias for `ppds publish --type webresource`. Auto-injects `--type webresource`. 
 
 **Rationale:** Standard stale-response protection pattern. Without it, the panel can show web resources from a previously selected solution after the user has already switched to a different one.
 
+### Why co-located tracking file per folder?
+
+**Context:** Pull/push needs state to detect conflicts and track what was downloaded. Options: (A) tracking file inside the target folder, (B) single tracking file at repo root, (C) solution-named files in a central `.ppds/` directory.
+
+**Decision:** Option A — `.ppds/webresources.json` co-located inside the target folder.
+
+**Rationale:** One folder = one pull context (typically one solution). Multi-solution support is achieved naturally by pulling to different folders. No central registry to maintain, no cross-referencing. The tracking file is self-contained and portable — move the folder, tracking moves with it. The `.ppds/` directory is a well-known convention for tool metadata (similar to `.git/`, `.vscode/`).
+
+**Alternatives considered:**
+- Central `.ppds/webresources.json` at repo root — harder to reason about with multiple pull targets, single point of contention
+- Solution-named files in `.ppds/webresources/` — requires push to discover which tracking file maps to which directory
+
+### Why SHA256 hash + modifiedOn dual tracking?
+
+**Context:** Need to detect both local changes (file edited after pull) and server changes (someone else edited in Dataverse).
+
+**Decision:** Track both SHA256 hash of local file content and server modifiedOn timestamp.
+
+**Rationale:** Hash detects local modifications without touching the server — fast, offline-capable. ModifiedOn detects server-side changes with a single lightweight query per resource. Together they enable the full conflict matrix: no changes (skip), local-only (safe to push), server-only (warn, suggest pull), both changed (conflict, block without --force).
+
+### Why a separate IWebResourceSyncService?
+
+**Context:** Could extend `IWebResourceService` with pull/push methods, or create a new service.
+
+**Decision:** New `IWebResourceSyncService` that depends on `IWebResourceService`.
+
+**Rationale:** Pull/push is a higher-level orchestration concern — file system I/O, tracking file management, parallel coordination, conflict detection. The existing `IWebResourceService` is a clean Dataverse CRUD interface. Mixing file system operations into it would violate single responsibility. The sync service composes the CRUD service rather than extending it.
+
 ---
 
 ## Changelog
 
 | Date | Change |
 |------|--------|
+| 2026-04-25 | Added pull/push workflow specification (#161, #162): IWebResourceSyncService, tracking file, pull/push CLI commands, ACs 34–55. Post-review fixes: path traversal protection, TOCTOU documentation, binary type scope, environment URL validation, tracking file merge semantics, deleted file handling |
 | 2026-03-23 | Added CLI surface (list, get, url), name resolution, publish alias; removed "offline editing" from non-goals (deferred to post-v1) |
 | 2026-03-18 | Extracted from panel-parity.md per SL1 |
 
@@ -296,7 +464,6 @@ Alias for `ppds publish --type webresource`. Auto-injects `--type webresource`. 
 
 ## Roadmap
 
-- **Pull/push workflow** — download web resources to local folder with hash tracking, push back with conflict detection (#161, #162)
 - **Diff** — local file vs server comparison, depends on pull/push (#163)
 
 ---

--- a/specs/web-resources.md
+++ b/specs/web-resources.md
@@ -248,7 +248,7 @@ Download web resources from Dataverse to a local folder with tracking metadata.
 
 ##### Push Command
 
-**`ppds webresources push <path> [--solution <name>] [--force] [--dry-run] [--publish]`**
+**`ppds webresources push <path> [--force] [--dry-run] [--publish]`**
 
 Upload modified web resources from a local folder back to Dataverse with conflict detection.
 
@@ -256,7 +256,6 @@ Upload modified web resources from a local folder back to Dataverse with conflic
 - `<path>` — folder containing pulled web resources (must have `.ppds/webresources.json`)
 
 **Options:**
-- `--solution <name>` — override solution scope for `--publish` (default: solution from tracking file). Does not affect content upload — `UpdateContentAsync` is solution-independent.
 - `--force` — skip conflict detection (push even if server has changed) and skip environment URL validation
 - `--dry-run` — preview what would be pushed without making changes (per dry-run convention)
 - `--publish` — publish all successfully pushed web resources after upload
@@ -456,7 +455,7 @@ Upload modified web resources from a local folder back to Dataverse with conflic
 
 | Date | Change |
 |------|--------|
-| 2026-04-25 | Added pull/push workflow specification (#161, #162): IWebResourceSyncService, tracking file, pull/push CLI commands, ACs 34–55. Post-review fixes: path traversal protection, TOCTOU documentation, binary type scope, environment URL validation, tracking file merge semantics, deleted file handling |
+| 2026-04-25 | Added pull/push workflow specification (#161, #162): IWebResourceSyncService, tracking file, pull/push CLI commands, ACs 34–55. Post-review fixes: path traversal protection, TOCTOU documentation, binary type scope, environment URL validation, tracking file merge semantics, deleted file handling. Dropped `--solution` from `push` because both `UpdateContentAsync` and `PublishAsync` are solution-independent — the option had nowhere to plumb through and would have been dead code. |
 | 2026-03-23 | Added CLI surface (list, get, url), name resolution, publish alias; removed "offline editing" from non-goals (deferred to post-v1) |
 | 2026-03-18 | Extracted from panel-parity.md per SL1 |
 

--- a/src/PPDS.Cli/Commands/WebResources/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/ListCommand.cs
@@ -14,29 +14,6 @@ namespace PPDS.Cli.Commands.WebResources;
 /// </summary>
 public static class ListCommand
 {
-    /// <summary>
-    /// Type shortcut mappings. "text" and "image" expand to multiple type codes.
-    /// Individual types map to their type code.
-    /// </summary>
-    private static readonly Dictionary<string, int[]> TypeMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["text"] = [1, 2, 3, 4, 9, 11, 12],     // HTML, CSS, JS, XML, XSL, SVG, RESX
-        ["image"] = [5, 6, 7, 10, 11],            // PNG, JPG, GIF, ICO, SVG
-        ["data"] = [4, 12],                        // XML, RESX
-        ["html"] = [1],
-        ["css"] = [2],
-        ["js"] = [3], ["javascript"] = [3],
-        ["xml"] = [4],
-        ["png"] = [5],
-        ["jpg"] = [6], ["jpeg"] = [6],
-        ["gif"] = [7],
-        ["xap"] = [8],
-        ["xsl"] = [9], ["xslt"] = [9],
-        ["ico"] = [10],
-        ["svg"] = [11],
-        ["resx"] = [12],
-    };
-
     public static Command Create()
     {
         var namePatternArgument = new Argument<string?>("name-pattern")
@@ -104,11 +81,11 @@ public static class ListCommand
         int[]? typeCodes = null;
         if (type != null)
         {
-            if (!TypeMap.TryGetValue(type, out typeCodes))
+            if (!WebResourceTypeMap.TryGetCodes(type, out typeCodes))
             {
                 var error = new StructuredError(
                     ErrorCodes.Validation.InvalidValue,
-                    $"Unknown type '{type}'. Supported: text, image, data, js, css, html, xml, png, jpg, gif, svg, ico, xsl, resx",
+                    $"Unknown type '{type}'. Supported: {WebResourceTypeMap.SupportedAliases}",
                     null,
                     type);
                 writer.WriteError(error);

--- a/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
@@ -61,12 +61,12 @@ public static class PullCommand
 
         var stripPrefixOption = new Option<bool>("--strip-prefix")
         {
-            Description = "Remove publisher prefix from local file paths (e.g., new_/scripts/app.js -> scripts/app.js)"
+            Description = "Remove the solution publisher prefix from local file paths (e.g., new_/scripts/app.js -> scripts/app.js). The prefix is org-specific and set by the solution publisher."
         };
 
         var forceOption = new Option<bool>("--force")
         {
-            Description = "Overwrite local files even if they have uncommitted changes"
+            Description = "Overwrite local files even when they differ from the last pulled version (hash mismatch)"
         };
 
         var command = new Command("pull", "Pull web resources to a local folder with tracking metadata")
@@ -192,7 +192,11 @@ public static class PullCommand
             {
                 var newCount = result.Pulled.Count(p => p.IsNew);
                 var updatedCount = result.Pulled.Count - newCount;
-                Console.Error.WriteLine($"Pulled {result.Pulled.Count} of {result.TotalServerCount} web resource(s) to {folder} ({newCount} new, {updatedCount} updated, {result.Skipped.Count} skipped, {result.Errors.Count} errors)");
+                var matched = result.Pulled.Count + result.Skipped.Count + result.Errors.Count;
+                var summary = matched == result.TotalServerCount
+                    ? $"Pulled {result.Pulled.Count} of {result.TotalServerCount} web resource(s) to {folder}"
+                    : $"Pulled {result.Pulled.Count} of {matched} matched web resource(s) to {folder} (filtered from {result.TotalServerCount} total)";
+                Console.Error.WriteLine($"{summary} ({newCount} new, {updatedCount} updated, {result.Skipped.Count} skipped, {result.Errors.Count} errors)");
 
                 if (result.Errors.Count > 0)
                 {

--- a/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
@@ -1,0 +1,269 @@
+using System.CommandLine;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.Solutions;
+using PPDS.Cli.Services.WebResources;
+
+namespace PPDS.Cli.Commands.WebResources;
+
+/// <summary>
+/// Pull web resources from a Dataverse environment to a local folder with tracking metadata.
+/// </summary>
+public static class PullCommand
+{
+    /// <summary>
+    /// Type shortcuts shared with <see cref="ListCommand"/>. Duplicated locally to avoid
+    /// exposing internal listcommand state; the small duplication is preferable to coupling.
+    /// </summary>
+    private static readonly Dictionary<string, int[]> TypeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["text"] = [1, 2, 3, 4, 9, 11, 12],
+        ["image"] = [5, 6, 7, 10, 11],
+        ["data"] = [4, 12],
+        ["html"] = [1],
+        ["css"] = [2],
+        ["js"] = [3], ["javascript"] = [3],
+        ["xml"] = [4],
+        ["png"] = [5],
+        ["jpg"] = [6], ["jpeg"] = [6],
+        ["gif"] = [7],
+        ["xap"] = [8],
+        ["xsl"] = [9], ["xslt"] = [9],
+        ["ico"] = [10],
+        ["svg"] = [11],
+        ["resx"] = [12],
+    };
+
+    public static Command Create()
+    {
+        var folderArgument = new Argument<string>("folder")
+        {
+            Description = "Target directory (created if missing)"
+        };
+
+        var solutionOption = new Option<string?>("--solution", "-s")
+        {
+            Description = "Filter by solution unique name"
+        };
+
+        var typeOption = new Option<string?>("--type", "-t")
+        {
+            Description = "Filter by type: text, image, data, or specific (js, css, html, xml, png, etc.)"
+        };
+
+        var nameOption = new Option<string?>("--name")
+        {
+            Description = "Filter by partial name match"
+        };
+
+        var stripPrefixOption = new Option<bool>("--strip-prefix")
+        {
+            Description = "Remove publisher prefix from local file paths (e.g., new_/scripts/app.js -> scripts/app.js)"
+        };
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Overwrite local files even if they have uncommitted changes"
+        };
+
+        var command = new Command("pull", "Pull web resources to a local folder with tracking metadata")
+        {
+            folderArgument,
+            WebResourcesCommandGroup.ProfileOption,
+            WebResourcesCommandGroup.EnvironmentOption,
+            solutionOption,
+            typeOption,
+            nameOption,
+            stripPrefixOption,
+            forceOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var folder = parseResult.GetValue(folderArgument)!;
+            var profile = parseResult.GetValue(WebResourcesCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(WebResourcesCommandGroup.EnvironmentOption);
+            var solution = parseResult.GetValue(solutionOption);
+            var type = parseResult.GetValue(typeOption);
+            var name = parseResult.GetValue(nameOption);
+            var stripPrefix = parseResult.GetValue(stripPrefixOption);
+            var force = parseResult.GetValue(forceOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(folder, profile, environment, solution, type, name, stripPrefix, force, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string folder,
+        string? profile,
+        string? environment,
+        string? solution,
+        string? type,
+        string? namePattern,
+        bool stripPrefix,
+        bool force,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        int[]? typeCodes = null;
+        if (type != null)
+        {
+            if (!TypeMap.TryGetValue(type, out typeCodes))
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Validation.InvalidValue,
+                    $"Unknown type '{type}'. Supported: text, image, data, js, css, html, xml, png, jpg, gif, svg, ico, xsl, resx",
+                    null,
+                    type));
+                return ExitCodes.InvalidArguments;
+            }
+        }
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            Guid? solutionId = null;
+            if (solution != null)
+            {
+                var solutionService = serviceProvider.GetRequiredService<ISolutionService>();
+                var solutionInfo = await solutionService.GetAsync(solution, cancellationToken);
+                if (solutionInfo == null)
+                {
+                    writer.WriteError(new StructuredError(
+                        ErrorCodes.Operation.NotFound,
+                        $"Solution '{solution}' not found.",
+                        null,
+                        solution));
+                    return ExitCodes.NotFoundError;
+                }
+                solutionId = solutionInfo.Id;
+            }
+
+            var sync = serviceProvider.GetRequiredService<IWebResourceSyncService>();
+            var pullOptions = new PullOptions(
+                Folder: folder,
+                EnvironmentUrl: connectionInfo.EnvironmentUrl,
+                SolutionId: solutionId,
+                SolutionUniqueName: solution,
+                TypeCodes: typeCodes,
+                NamePattern: namePattern,
+                StripPrefix: stripPrefix,
+                Force: force);
+
+            var result = await sync.PullAsync(pullOptions, progress: null, cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(new PullOutput
+                {
+                    Folder = folder,
+                    TotalServerCount = result.TotalServerCount,
+                    Pulled = result.Pulled.Select(p => new PulledOutput { Name = p.Name, LocalPath = p.LocalPath, IsNew = p.IsNew }).ToList(),
+                    Skipped = result.Skipped.Select(s => new SkippedOutput { Name = s.Name, Reason = s.Reason }).ToList(),
+                    Errors = result.Errors.Select(e => new ErrorOutput { Name = e.Name, Error = e.Error }).ToList(),
+                });
+            }
+            else
+            {
+                var newCount = result.Pulled.Count(p => p.IsNew);
+                var updatedCount = result.Pulled.Count - newCount;
+                Console.Error.WriteLine($"Pulled {result.Pulled.Count} of {result.TotalServerCount} web resource(s) to {folder} ({newCount} new, {updatedCount} updated, {result.Skipped.Count} skipped, {result.Errors.Count} errors)");
+
+                if (result.Errors.Count > 0)
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine("Errors:");
+                    foreach (var err in result.Errors)
+                    {
+                        Console.Error.WriteLine($"  {err.Name}: {err.Error}");
+                    }
+                }
+            }
+
+            return result.Errors.Count > 0 ? ExitCodes.PartialSuccess : ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: $"pulling web resources to '{folder}'", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #region Output Models
+
+    private sealed class PullOutput
+    {
+        [JsonPropertyName("folder")]
+        public string Folder { get; set; } = string.Empty;
+
+        [JsonPropertyName("totalServerCount")]
+        public int TotalServerCount { get; set; }
+
+        [JsonPropertyName("pulled")]
+        public List<PulledOutput> Pulled { get; set; } = [];
+
+        [JsonPropertyName("skipped")]
+        public List<SkippedOutput> Skipped { get; set; } = [];
+
+        [JsonPropertyName("errors")]
+        public List<ErrorOutput> Errors { get; set; } = [];
+    }
+
+    private sealed class PulledOutput
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("localPath")]
+        public string LocalPath { get; set; } = string.Empty;
+
+        [JsonPropertyName("isNew")]
+        public bool IsNew { get; set; }
+    }
+
+    private sealed class SkippedOutput
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; } = string.Empty;
+    }
+
+    private sealed class ErrorOutput
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("error")]
+        public string Error { get; set; } = string.Empty;
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
@@ -14,29 +14,6 @@ namespace PPDS.Cli.Commands.WebResources;
 /// </summary>
 public static class PullCommand
 {
-    /// <summary>
-    /// Type shortcuts shared with <see cref="ListCommand"/>. Duplicated locally to avoid
-    /// exposing internal listcommand state; the small duplication is preferable to coupling.
-    /// </summary>
-    private static readonly Dictionary<string, int[]> TypeMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["text"] = [1, 2, 3, 4, 9, 11, 12],
-        ["image"] = [5, 6, 7, 10, 11],
-        ["data"] = [4, 12],
-        ["html"] = [1],
-        ["css"] = [2],
-        ["js"] = [3], ["javascript"] = [3],
-        ["xml"] = [4],
-        ["png"] = [5],
-        ["jpg"] = [6], ["jpeg"] = [6],
-        ["gif"] = [7],
-        ["xap"] = [8],
-        ["xsl"] = [9], ["xslt"] = [9],
-        ["ico"] = [10],
-        ["svg"] = [11],
-        ["resx"] = [12],
-    };
-
     public static Command Create()
     {
         var folderArgument = new Argument<string>("folder")
@@ -66,7 +43,7 @@ public static class PullCommand
 
         var forceOption = new Option<bool>("--force")
         {
-            Description = "Overwrite local files even when they differ from the last pulled version (hash mismatch)"
+            Description = "Overwrite local files even when they have been edited since the last pull"
         };
 
         var command = new Command("pull", "Pull web resources to a local folder with tracking metadata")
@@ -118,11 +95,11 @@ public static class PullCommand
         int[]? typeCodes = null;
         if (type != null)
         {
-            if (!TypeMap.TryGetValue(type, out typeCodes))
+            if (!WebResourceTypeMap.TryGetCodes(type, out typeCodes))
             {
                 writer.WriteError(new StructuredError(
                     ErrorCodes.Validation.InvalidValue,
-                    $"Unknown type '{type}'. Supported: text, image, data, js, css, html, xml, png, jpg, gif, svg, ico, xsl, resx",
+                    $"Unknown type '{type}'. Supported: {WebResourceTypeMap.SupportedAliases}",
                     null,
                     type));
                 return ExitCodes.InvalidArguments;
@@ -175,7 +152,8 @@ public static class PullCommand
                 StripPrefix: stripPrefix,
                 Force: force);
 
-            var result = await sync.PullAsync(pullOptions, progress: null, cancellationToken);
+            IOperationProgress? progress = globalOptions.IsJsonMode ? null : new StderrOperationProgress();
+            var result = await sync.PullAsync(pullOptions, progress, cancellationToken);
 
             if (globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PullCommand.cs
@@ -28,7 +28,7 @@ public static class PullCommand
 
         var typeOption = new Option<string?>("--type", "-t")
         {
-            Description = "Filter by type: text, image, data, or specific (js, css, html, xml, png, etc.)"
+            Description = "Filter by type: text, image, data, or specific type (js, css, html, xml, png, etc.)"
         };
 
         var nameOption = new Option<string?>("--name")

--- a/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
@@ -22,17 +22,17 @@ public static class PushCommand
 
         var forceOption = new Option<bool>("--force")
         {
-            Description = "Skip conflict detection and environment URL validation"
+            Description = "Skip safety checks: server-conflict detection (someone edited since last pull) and environment URL validation (pulled from a different env than the current connection)"
         };
 
         var dryRunOption = new Option<bool>("--dry-run")
         {
-            Description = "Preview what would be pushed without making changes"
+            Description = "Preview what would be pushed without uploading. Still authenticates and queries the server for conflict detection."
         };
 
         var publishOption = new Option<bool>("--publish")
         {
-            Description = "Publish all successfully uploaded web resources after upload"
+            Description = "After upload, run the Dataverse Publish step on the uploaded resources (required before changes take effect in apps)"
         };
 
         var command = new Command("push", "Push locally-modified web resources back to Dataverse")

--- a/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
@@ -1,0 +1,231 @@
+using System.CommandLine;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.WebResources;
+
+namespace PPDS.Cli.Commands.WebResources;
+
+/// <summary>
+/// Push locally-modified web resources back to Dataverse with conflict detection.
+/// </summary>
+public static class PushCommand
+{
+    public static Command Create()
+    {
+        var pathArgument = new Argument<string>("path")
+        {
+            Description = "Folder containing pulled web resources (must have .ppds/webresources.json)"
+        };
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Skip conflict detection and environment URL validation"
+        };
+
+        var dryRunOption = new Option<bool>("--dry-run")
+        {
+            Description = "Preview what would be pushed without making changes"
+        };
+
+        var publishOption = new Option<bool>("--publish")
+        {
+            Description = "Publish all successfully uploaded web resources after upload"
+        };
+
+        var command = new Command("push", "Push locally-modified web resources back to Dataverse")
+        {
+            pathArgument,
+            WebResourcesCommandGroup.ProfileOption,
+            WebResourcesCommandGroup.EnvironmentOption,
+            forceOption,
+            dryRunOption,
+            publishOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var path = parseResult.GetValue(pathArgument)!;
+            var profile = parseResult.GetValue(WebResourcesCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(WebResourcesCommandGroup.EnvironmentOption);
+            var force = parseResult.GetValue(forceOption);
+            var dryRun = parseResult.GetValue(dryRunOption);
+            var publish = parseResult.GetValue(publishOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(path, profile, environment, force, dryRun, publish, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string path,
+        string? profile,
+        string? environment,
+        bool force,
+        bool dryRun,
+        bool publish,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            var sync = serviceProvider.GetRequiredService<IWebResourceSyncService>();
+            var pushOptions = new PushOptions(
+                Folder: path,
+                CurrentEnvironmentUrl: connectionInfo.EnvironmentUrl,
+                Force: force,
+                DryRun: dryRun,
+                Publish: publish);
+
+            var result = await sync.PushAsync(pushOptions, progress: null, cancellationToken);
+
+            if (result.Conflicts.Count > 0)
+            {
+                if (globalOptions.IsJsonMode)
+                {
+                    writer.WriteSuccess(BuildOutput(path, result));
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Conflicts detected: {result.Conflicts.Count} resource(s) have changed on the server since last pull.");
+                    Console.Error.WriteLine();
+                    foreach (var conflict in result.Conflicts)
+                    {
+                        Console.Error.WriteLine($"  {conflict.Name}");
+                        Console.Error.WriteLine($"    tracked: {conflict.TrackedModifiedOn:o}");
+                        Console.Error.WriteLine($"    server:  {conflict.ServerModifiedOn:o}");
+                    }
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"Run 'ppds webresources pull {path}' to fetch latest changes, or use --force to push anyway.");
+                }
+                return ExitCodes.PreconditionFailed;
+            }
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(BuildOutput(path, result));
+            }
+            else
+            {
+                if (result.DryRun)
+                {
+                    Console.Error.WriteLine($"Dry run: would push {result.Pushed.Count} web resource(s) ({result.Skipped.Count} skipped)");
+                    foreach (var p in result.Pushed)
+                    {
+                        Console.Error.WriteLine($"  + {p.Name}");
+                    }
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Pushed {result.Pushed.Count} web resource(s) ({result.Skipped.Count} skipped)");
+                    if (publish)
+                    {
+                        Console.Error.WriteLine($"Published {result.PublishedCount} web resource(s)");
+                    }
+                }
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: $"pushing web resources from '{path}'", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static PushOutput BuildOutput(string path, PushResult result) => new()
+    {
+        Folder = path,
+        DryRun = result.DryRun,
+        PublishedCount = result.PublishedCount,
+        Pushed = result.Pushed.Select(p => new PushedOutput { Name = p.Name, LocalPath = p.LocalPath }).ToList(),
+        Conflicts = result.Conflicts.Select(c => new ConflictOutput
+        {
+            Name = c.Name,
+            TrackedModifiedOn = c.TrackedModifiedOn,
+            ServerModifiedOn = c.ServerModifiedOn,
+        }).ToList(),
+        Skipped = result.Skipped.Select(s => new SkippedOutput { Name = s.Name, Reason = s.Reason }).ToList(),
+    };
+
+    #region Output Models
+
+    private sealed class PushOutput
+    {
+        [JsonPropertyName("folder")]
+        public string Folder { get; set; } = string.Empty;
+
+        [JsonPropertyName("dryRun")]
+        public bool DryRun { get; set; }
+
+        [JsonPropertyName("publishedCount")]
+        public int PublishedCount { get; set; }
+
+        [JsonPropertyName("pushed")]
+        public List<PushedOutput> Pushed { get; set; } = [];
+
+        [JsonPropertyName("conflicts")]
+        public List<ConflictOutput> Conflicts { get; set; } = [];
+
+        [JsonPropertyName("skipped")]
+        public List<SkippedOutput> Skipped { get; set; } = [];
+    }
+
+    private sealed class PushedOutput
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("localPath")]
+        public string LocalPath { get; set; } = string.Empty;
+    }
+
+    private sealed class ConflictOutput
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("trackedModifiedOn")]
+        public DateTime? TrackedModifiedOn { get; set; }
+
+        [JsonPropertyName("serverModifiedOn")]
+        public DateTime? ServerModifiedOn { get; set; }
+    }
+
+    private sealed class SkippedOutput
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; } = string.Empty;
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
@@ -101,13 +101,24 @@ public static class PushCommand
                 DryRun: dryRun,
                 Publish: publish);
 
-            var result = await sync.PushAsync(pushOptions, progress: null, cancellationToken);
+            IOperationProgress? progress = globalOptions.IsJsonMode ? null : new StderrOperationProgress();
+            var result = await sync.PushAsync(pushOptions, progress, cancellationToken);
 
             if (result.Conflicts.Count > 0)
             {
                 if (globalOptions.IsJsonMode)
                 {
-                    writer.WriteSuccess(BuildOutput(path, result));
+                    var conflictError = new StructuredError(
+                        ErrorCodes.WebResource.Conflict,
+                        $"Push blocked: {result.Conflicts.Count} resource(s) have changed on the server since last pull. Run 'ppds webresources pull {path}' to fetch latest changes, or use --force to push anyway.",
+                        null,
+                        path);
+                    writer.WriteResult(new CommandResult<PushOutput>
+                    {
+                        Success = false,
+                        Data = BuildOutput(path, result),
+                        Error = conflictError,
+                    });
                 }
                 else
                 {
@@ -141,15 +152,25 @@ public static class PushCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Pushed {result.Pushed.Count} web resource(s) ({result.Skipped.Count} skipped)");
+                    Console.Error.WriteLine($"Pushed {result.Pushed.Count} web resource(s) ({result.Skipped.Count} skipped, {result.Errors.Count} errors)");
                     if (publish)
                     {
                         Console.Error.WriteLine($"Published {result.PublishedCount} web resource(s)");
                     }
                 }
+
+                if (result.Errors.Count > 0)
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine("Errors:");
+                    foreach (var err in result.Errors)
+                    {
+                        Console.Error.WriteLine($"  {err.Name}: {err.Error}");
+                    }
+                }
             }
 
-            return ExitCodes.Success;
+            return result.Errors.Count > 0 ? ExitCodes.PartialSuccess : ExitCodes.Success;
         }
         catch (Exception ex)
         {
@@ -172,6 +193,7 @@ public static class PushCommand
             ServerModifiedOn = c.ServerModifiedOn,
         }).ToList(),
         Skipped = result.Skipped.Select(s => new SkippedOutput { Name = s.Name, Reason = s.Reason }).ToList(),
+        Errors = result.Errors.Select(e => new ErrorOutput { Name = e.Name, Error = e.Error }).ToList(),
     };
 
     #region Output Models
@@ -195,6 +217,9 @@ public static class PushCommand
 
         [JsonPropertyName("skipped")]
         public List<SkippedOutput> Skipped { get; set; } = [];
+
+        [JsonPropertyName("errors")]
+        public List<ErrorOutput> Errors { get; set; } = [];
     }
 
     private sealed class PushedOutput
@@ -225,6 +250,15 @@ public static class PushCommand
 
         [JsonPropertyName("reason")]
         public string Reason { get; set; } = string.Empty;
+    }
+
+    private sealed class ErrorOutput
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("error")]
+        public string Error { get; set; } = string.Empty;
     }
 
     #endregion

--- a/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/PushCommand.cs
@@ -15,9 +15,9 @@ public static class PushCommand
 {
     public static Command Create()
     {
-        var pathArgument = new Argument<string>("path")
+        var folderArgument = new Argument<string>("folder")
         {
-            Description = "Folder containing pulled web resources (must have .ppds/webresources.json)"
+            Description = "Folder previously populated by 'ppds webresources pull'"
         };
 
         var forceOption = new Option<bool>("--force")
@@ -37,7 +37,7 @@ public static class PushCommand
 
         var command = new Command("push", "Push locally-modified web resources back to Dataverse")
         {
-            pathArgument,
+            folderArgument,
             WebResourcesCommandGroup.ProfileOption,
             WebResourcesCommandGroup.EnvironmentOption,
             forceOption,
@@ -49,7 +49,7 @@ public static class PushCommand
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {
-            var path = parseResult.GetValue(pathArgument)!;
+            var path = parseResult.GetValue(folderArgument)!;
             var profile = parseResult.GetValue(WebResourcesCommandGroup.ProfileOption);
             var environment = parseResult.GetValue(WebResourcesCommandGroup.EnvironmentOption);
             var force = parseResult.GetValue(forceOption);
@@ -74,6 +74,20 @@ public static class PushCommand
         CancellationToken cancellationToken)
     {
         var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        // Validate filesystem preconditions before authenticating — avoids a wasted auth round-trip
+        // (and a misleading "Connected as ..." banner) when the user pointed push at a folder that
+        // hasn't been pulled yet.
+        try
+        {
+            ValidatePushTarget(path);
+        }
+        catch (PpdsException ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: $"pushing web resources from '{path}'", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
 
         try
         {
@@ -177,6 +191,38 @@ public static class PushCommand
             var error = ExceptionMapper.Map(ex, context: $"pushing web resources from '{path}'", debug: globalOptions.Debug);
             writer.WriteError(error);
             return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    /// <summary>
+    /// Cheap filesystem check executed before authenticating to Dataverse. Mirrors the
+    /// preconditions enforced by <see cref="WebResourceSyncService.PushAsync"/> so the user
+    /// gets the same error without paying for an auth round-trip.
+    /// </summary>
+    private static void ValidatePushTarget(string path)
+    {
+        var rootAbsolute = Path.GetFullPath(path);
+
+        if (File.Exists(rootAbsolute))
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.InvalidValue,
+                $"Path '{path}' is a file, not a folder. Pass the folder that contains the pulled web resources (the folder with the .ppds/webresources.json tracking file).");
+        }
+
+        if (!Directory.Exists(rootAbsolute))
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.FileNotFound,
+                $"Folder '{path}' does not exist. Run 'ppds webresources pull {path}' first.");
+        }
+
+        var trackingPath = Path.Combine(rootAbsolute, WebResourceTrackingFile.TrackingFileRelativePath);
+        if (!File.Exists(trackingPath))
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.FileNotFound,
+                $"Tracking file '{WebResourceTrackingFile.TrackingFileRelativePath}' not found in '{path}'. Run 'ppds webresources pull {path}' first.");
         }
     }
 

--- a/src/PPDS.Cli/Commands/WebResources/WebResourceTypeMap.cs
+++ b/src/PPDS.Cli/Commands/WebResources/WebResourceTypeMap.cs
@@ -1,0 +1,50 @@
+namespace PPDS.Cli.Commands.WebResources;
+
+/// <summary>
+/// Type-shortcut mappings shared by web-resource CLI commands (list, pull).
+/// "text" and "image" expand to multiple type codes; individual aliases map to
+/// a single Dataverse webresourcetype value (1-12).
+/// </summary>
+internal static class WebResourceTypeMap
+{
+    /// <summary>
+    /// Comma-separated list of supported aliases, used in error messages.
+    /// </summary>
+    public const string SupportedAliases = "text, image, data, js, css, html, xml, png, jpg, gif, svg, ico, xsl, resx";
+
+    private static readonly Dictionary<string, int[]> Map = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["text"] = [1, 2, 3, 4, 9, 11, 12],     // HTML, CSS, JS, XML, XSL, SVG, RESX
+        ["image"] = [5, 6, 7, 10, 11],          // PNG, JPG, GIF, ICO, SVG
+        ["data"] = [4, 12],                     // XML, RESX
+        ["html"] = [1],
+        ["css"] = [2],
+        ["js"] = [3], ["javascript"] = [3],
+        ["xml"] = [4],
+        ["png"] = [5],
+        ["jpg"] = [6], ["jpeg"] = [6],
+        ["gif"] = [7],
+        ["xap"] = [8],
+        ["xsl"] = [9], ["xslt"] = [9],
+        ["ico"] = [10],
+        ["svg"] = [11],
+        ["resx"] = [12],
+    };
+
+    /// <summary>
+    /// Resolves a type alias to the matching set of webresourcetype codes.
+    /// </summary>
+    /// <param name="alias">Type alias (case-insensitive).</param>
+    /// <param name="codes">The matching codes when the alias is recognised.</param>
+    /// <returns>True if the alias is recognised; false otherwise.</returns>
+    public static bool TryGetCodes(string alias, out int[]? codes)
+    {
+        if (Map.TryGetValue(alias, out var found))
+        {
+            codes = found;
+            return true;
+        }
+        codes = null;
+        return false;
+    }
+}

--- a/src/PPDS.Cli/Commands/WebResources/WebResourcesCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/WebResources/WebResourcesCommandGroup.cs
@@ -28,13 +28,14 @@ public static class WebResourcesCommandGroup
     /// </summary>
     public static Command Create()
     {
-        var command = new Command("webresources", "Manage Dataverse web resources: list, get, url, publish, pull");
+        var command = new Command("webresources", "Manage Dataverse web resources: list, get, url, publish, pull, push");
 
         command.Subcommands.Add(ListCommand.Create());
         command.Subcommands.Add(GetCommand.Create());
         command.Subcommands.Add(UrlCommand.Create());
         command.Subcommands.Add(PublishAliasCommand.Create());
         command.Subcommands.Add(PullCommand.Create());
+        command.Subcommands.Add(PushCommand.Create());
 
         return command;
     }

--- a/src/PPDS.Cli/Commands/WebResources/WebResourcesCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/WebResources/WebResourcesCommandGroup.cs
@@ -28,12 +28,13 @@ public static class WebResourcesCommandGroup
     /// </summary>
     public static Command Create()
     {
-        var command = new Command("webresources", "Manage Dataverse web resources: list, get, url, publish");
+        var command = new Command("webresources", "Manage Dataverse web resources: list, get, url, publish, pull");
 
         command.Subcommands.Add(ListCommand.Create());
         command.Subcommands.Add(GetCommand.Create());
         command.Subcommands.Add(UrlCommand.Create());
         command.Subcommands.Add(PublishAliasCommand.Create());
+        command.Subcommands.Add(PullCommand.Create());
 
         return command;
     }

--- a/src/PPDS.Cli/Infrastructure/StderrOperationProgress.cs
+++ b/src/PPDS.Cli/Infrastructure/StderrOperationProgress.cs
@@ -1,0 +1,85 @@
+namespace PPDS.Cli.Infrastructure;
+
+/// <summary>
+/// Stderr adapter for <see cref="IOperationProgress"/>. Renders progress as a
+/// carriage-return-updated line so it overwrites in place on a TTY, then
+/// terminates with a newline on completion or error.
+/// </summary>
+/// <remarks>
+/// Why stderr: Constitution I1 reserves stdout for data so that command output
+/// remains pipeable. Status, progress, and diagnostics belong on stderr.
+/// </remarks>
+public sealed class StderrOperationProgress : IOperationProgress
+{
+    private readonly TextWriter _writer;
+    private bool _hasInlineLine;
+
+    /// <summary>
+    /// Creates a stderr progress reporter.
+    /// </summary>
+    /// <param name="writer">Defaults to <see cref="Console.Error"/> when null.</param>
+    public StderrOperationProgress(TextWriter? writer = null)
+    {
+        _writer = writer ?? Console.Error;
+    }
+
+    /// <inheritdoc />
+    public void ReportStatus(string message)
+    {
+        EndInlineLine();
+        _writer.WriteLine(message);
+    }
+
+    /// <inheritdoc />
+    public void ReportProgress(int current, int total, string? message = null)
+    {
+        var label = string.IsNullOrEmpty(message) ? string.Empty : $" {message}";
+        if (total > 0)
+        {
+            var pct = (double)current / total * 100.0;
+            WriteInline($"  Progress: {current:N0}/{total:N0} ({pct:F1}%){label}");
+        }
+        else
+        {
+            WriteInline($"  Progress: {current:N0}{label}");
+        }
+    }
+
+    /// <inheritdoc />
+    public void ReportProgress(double fraction, string? message = null)
+    {
+        var pct = Math.Clamp(fraction, 0.0, 1.0) * 100.0;
+        var label = string.IsNullOrEmpty(message) ? string.Empty : $" {message}";
+        WriteInline($"  Progress: {pct:F1}%{label}");
+    }
+
+    /// <inheritdoc />
+    public void ReportComplete(string message)
+    {
+        EndInlineLine();
+        _writer.WriteLine(message);
+    }
+
+    /// <inheritdoc />
+    public void ReportError(string message)
+    {
+        EndInlineLine();
+        _writer.WriteLine($"Error: {message}");
+    }
+
+    private void WriteInline(string text)
+    {
+        _writer.Write($"\r{text}");
+        _writer.Flush();
+        _hasInlineLine = true;
+    }
+
+    private void EndInlineLine()
+    {
+        if (_hasInlineLine)
+        {
+            _writer.WriteLine();
+            _hasInlineLine = false;
+        }
+    }
+}

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -227,6 +227,10 @@ public static class ServiceRegistration
             sp.GetRequiredService<IShakedownGuard>(),
             sp.GetRequiredService<ILogger<WebResourceService>>()));
 
+        services.AddTransient<IWebResourceSyncService>(sp => new WebResourceSyncService(
+            sp.GetRequiredService<IWebResourceService>(),
+            sp.GetRequiredService<ILogger<WebResourceSyncService>>()));
+
         services.AddTransient<IEnvironmentVariableService>(sp => new EnvironmentVariableService(
             sp.GetRequiredService<IDataverseConnectionPool>(),
             sp.GetRequiredService<IShakedownGuard>(),

--- a/src/PPDS.Cli/Services/WebResources/IWebResourceSyncService.cs
+++ b/src/PPDS.Cli/Services/WebResources/IWebResourceSyncService.cs
@@ -85,12 +85,14 @@ public sealed record ErrorResource(string Name, string Error);
 /// <param name="Pushed">Resources successfully uploaded (or that would be in dry-run).</param>
 /// <param name="Conflicts">Conflicts detected: server modifiedOn differs from tracked.</param>
 /// <param name="Skipped">Resources skipped (unchanged, binary, missing, etc.).</param>
+/// <param name="Errors">Resources that errored during the push (per-item upload, refresh, or publish failures).</param>
 /// <param name="DryRun">True if this was a dry-run (no mutations applied).</param>
 /// <param name="PublishedCount">Number of resources published (only when Publish=true and not DryRun).</param>
 public sealed record PushResult(
     IReadOnlyList<PushedResource> Pushed,
     IReadOnlyList<ConflictResource> Conflicts,
     IReadOnlyList<SkippedResource> Skipped,
+    IReadOnlyList<ErrorResource> Errors,
     bool DryRun,
     int PublishedCount);
 

--- a/src/PPDS.Cli/Services/WebResources/IWebResourceSyncService.cs
+++ b/src/PPDS.Cli/Services/WebResources/IWebResourceSyncService.cs
@@ -1,0 +1,101 @@
+using PPDS.Cli.Infrastructure;
+
+namespace PPDS.Cli.Services.WebResources;
+
+/// <summary>
+/// Application service that orchestrates pull and push of web resources between
+/// Dataverse and a local folder. Owns tracking-file management, parallel I/O,
+/// and conflict detection (Constitution A1, A2).
+/// </summary>
+public interface IWebResourceSyncService
+{
+    /// <summary>
+    /// Lists web resources, applies filters, downloads text content in parallel,
+    /// writes files to disk, and persists the tracking file.
+    /// </summary>
+    Task<PullResult> PullAsync(PullOptions options, IOperationProgress? progress, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the tracking file, detects local edits, checks for server conflicts,
+    /// uploads modified text resources in parallel, and updates the tracking file.
+    /// </summary>
+    Task<PushResult> PushAsync(PushOptions options, IOperationProgress? progress, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Inputs for <see cref="IWebResourceSyncService.PullAsync"/>.
+/// </summary>
+/// <param name="Folder">Target directory (created if missing).</param>
+/// <param name="EnvironmentUrl">Environment URL of the current connection (recorded in tracking file).</param>
+/// <param name="SolutionId">Optional solution component filter.</param>
+/// <param name="SolutionUniqueName">Optional solution unique name (for tracking-file display).</param>
+/// <param name="TypeCodes">Optional client-side type-code filter (1-12).</param>
+/// <param name="NamePattern">Optional partial-name filter (substring match).</param>
+/// <param name="StripPrefix">If true, removes the publisher prefix from local paths.</param>
+/// <param name="Force">If true, overwrites locally modified files.</param>
+public sealed record PullOptions(
+    string Folder,
+    string EnvironmentUrl,
+    Guid? SolutionId,
+    string? SolutionUniqueName,
+    int[]? TypeCodes,
+    string? NamePattern,
+    bool StripPrefix,
+    bool Force);
+
+/// <summary>
+/// Inputs for <see cref="IWebResourceSyncService.PushAsync"/>.
+/// </summary>
+/// <param name="Folder">Folder containing pulled web resources.</param>
+/// <param name="CurrentEnvironmentUrl">Environment URL of the current connection.</param>
+/// <param name="Force">If true, skips conflict detection and environment URL validation.</param>
+/// <param name="DryRun">If true, reports what would be pushed without making changes.</param>
+/// <param name="Publish">If true, publishes successfully uploaded resources after upload.</param>
+public sealed record PushOptions(
+    string Folder,
+    string CurrentEnvironmentUrl,
+    bool Force,
+    bool DryRun,
+    bool Publish);
+
+/// <summary>Outcome of a pull operation.</summary>
+/// <param name="TotalServerCount">Total resources returned by the server (pre-filter) — for I4 visibility.</param>
+/// <param name="Pulled">Resources successfully written to disk.</param>
+/// <param name="Skipped">Resources skipped (locally modified, binary, etc.).</param>
+/// <param name="Errors">Resources that failed (e.g., path traversal).</param>
+public sealed record PullResult(
+    int TotalServerCount,
+    IReadOnlyList<PulledResource> Pulled,
+    IReadOnlyList<SkippedResource> Skipped,
+    IReadOnlyList<ErrorResource> Errors);
+
+/// <summary>A resource that was downloaded and written.</summary>
+/// <param name="Name">The Dataverse web resource name.</param>
+/// <param name="LocalPath">The local file path written.</param>
+/// <param name="IsNew">True if the file did not exist before this pull.</param>
+public sealed record PulledResource(string Name, string LocalPath, bool IsNew);
+
+/// <summary>A resource that was skipped for a non-error reason.</summary>
+public sealed record SkippedResource(string Name, string Reason);
+
+/// <summary>A resource that errored during processing.</summary>
+public sealed record ErrorResource(string Name, string Error);
+
+/// <summary>Outcome of a push operation.</summary>
+/// <param name="Pushed">Resources successfully uploaded (or that would be in dry-run).</param>
+/// <param name="Conflicts">Conflicts detected: server modifiedOn differs from tracked.</param>
+/// <param name="Skipped">Resources skipped (unchanged, binary, missing, etc.).</param>
+/// <param name="DryRun">True if this was a dry-run (no mutations applied).</param>
+/// <param name="PublishedCount">Number of resources published (only when Publish=true and not DryRun).</param>
+public sealed record PushResult(
+    IReadOnlyList<PushedResource> Pushed,
+    IReadOnlyList<ConflictResource> Conflicts,
+    IReadOnlyList<SkippedResource> Skipped,
+    bool DryRun,
+    int PublishedCount);
+
+/// <summary>A resource that was uploaded.</summary>
+public sealed record PushedResource(string Name, string LocalPath);
+
+/// <summary>A resource where the server has changed since the tracked baseline.</summary>
+public sealed record ConflictResource(string Name, DateTime? TrackedModifiedOn, DateTime? ServerModifiedOn);

--- a/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
@@ -224,10 +224,25 @@ public class WebResourceSyncService : IWebResourceSyncService
         ArgumentNullException.ThrowIfNull(options);
 
         var rootAbsolute = Path.GetFullPath(options.Folder);
+
+        if (File.Exists(rootAbsolute))
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.InvalidValue,
+                $"Path '{options.Folder}' is a file, not a folder. Pass the folder that contains the pulled web resources (the folder with the .ppds/webresources.json tracking file).");
+        }
+
+        if (!Directory.Exists(rootAbsolute))
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.FileNotFound,
+                $"Folder '{options.Folder}' does not exist. Run 'ppds webresources pull {options.Folder}' first.");
+        }
+
         var tracking = await WebResourceTrackingFile.ReadAsync(rootAbsolute, cancellationToken)
             ?? throw new PpdsException(
                 ErrorCodes.Validation.FileNotFound,
-                $"Tracking file '{WebResourceTrackingFile.TrackingFileRelativePath}' not found in '{options.Folder}'. Run 'ppds webresources pull' first.");
+                $"Tracking file '{WebResourceTrackingFile.TrackingFileRelativePath}' not found in '{options.Folder}'. Run 'ppds webresources pull {options.Folder}' first.");
 
         if (!options.Force && !UrlsEqual(tracking.EnvironmentUrl, options.CurrentEnvironmentUrl))
         {

--- a/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
@@ -14,6 +14,11 @@ public class WebResourceSyncService : IWebResourceSyncService
     private const int DefaultDownloadParallelism = 8;
     private const int DefaultUploadParallelism = 4;
 
+    // Path comparisons must be case-sensitive on POSIX, case-insensitive on Windows.
+    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
     private readonly IWebResourceService _webResourceService;
     private readonly ILogger<WebResourceSyncService> _logger;
 
@@ -58,9 +63,9 @@ public class WebResourceSyncService : IWebResourceSyncService
         var rootAbsolute = Path.GetFullPath(options.Folder);
         Directory.CreateDirectory(rootAbsolute);
 
-        var existingTracking = options.Force
-            ? null
-            : await WebResourceTrackingFile.ReadAsync(rootAbsolute, cancellationToken);
+        // Always read existing tracking — Force only governs the local-hash check below.
+        // Skipping the read would erase out-of-scope entries on a partial pull.
+        var existingTracking = await WebResourceTrackingFile.ReadAsync(rootAbsolute, cancellationToken);
 
         var pulled = new List<PulledResource>();
         var skipped = new List<SkippedResource>();
@@ -72,6 +77,12 @@ public class WebResourceSyncService : IWebResourceSyncService
         var processable = new List<(WebResourceInfo Resource, string LocalPath, string AbsolutePath)>();
         foreach (var resource in filtered)
         {
+            if (IsUnsafeResourceName(resource.Name))
+            {
+                errors.Add(new ErrorResource(resource.Name, ErrorCodes.Validation.PathOutsideWorkspace));
+                continue;
+            }
+
             var localPath = ComputeLocalPath(resource.Name, options.StripPrefix, resource.FileExtension);
             var absolutePath = Path.GetFullPath(Path.Combine(rootAbsolute, localPath));
             if (!IsDescendantOf(absolutePath, rootAbsolute))
@@ -82,7 +93,7 @@ public class WebResourceSyncService : IWebResourceSyncService
             processable.Add((resource, localPath, absolutePath));
         }
 
-        // Local-modification check (skip when --force)
+        // Local-modification check (skipped on hash mismatch unless --force).
         var toDownload = new List<(WebResourceInfo Resource, string LocalPath, string AbsolutePath, bool IsNew)>();
         foreach (var (resource, localPath, absolutePath) in processable)
         {
@@ -94,12 +105,21 @@ public class WebResourceSyncService : IWebResourceSyncService
             }
 
             var existsLocally = File.Exists(absolutePath);
-            if (existingTracking != null && existsLocally && existingTracking.Resources.TryGetValue(resource.Name, out var prior))
+            if (!options.Force && existsLocally)
             {
-                var localHash = await WebResourceTrackingFile.ComputeHashAsync(absolutePath, cancellationToken);
-                if (!string.Equals(localHash, prior.Hash, StringComparison.OrdinalIgnoreCase))
+                if (existingTracking != null && existingTracking.Resources.TryGetValue(resource.Name, out var prior))
                 {
-                    skipped.Add(new SkippedResource(resource.Name, "locally modified"));
+                    var localHash = await WebResourceTrackingFile.ComputeHashAsync(absolutePath, cancellationToken);
+                    if (!string.Equals(localHash, prior.Hash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        skipped.Add(new SkippedResource(resource.Name, "locally modified"));
+                        continue;
+                    }
+                }
+                else
+                {
+                    // Untracked local file present (no prior tracking entry). Don't clobber.
+                    skipped.Add(new SkippedResource(resource.Name, "untracked local file exists"));
                     continue;
                 }
             }
@@ -184,21 +204,28 @@ public class WebResourceSyncService : IWebResourceSyncService
                 resource.WebResourceType);
         }
 
-        // Merge: locally modified (skipped) entries retain prior tracking; resources no longer
-        // returned by the server are pruned. Errored entries also retain prior tracking when present.
-        var skippedNames = skipped.Select(s => s.Name)
-            .Concat(errors.Select(e => e.Name))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
+        // Merge semantics. Two distinct cases for an entry already in tracking:
+        //   1. Present on the server but filtered out by --name/--type (out of scope): the pull
+        //      never queried it ⇒ preserve the prior entry untouched.
+        //   2. Present on the server and in scope: freshly downloaded entries win; skipped or
+        //      errored entries retain their prior tracking.
+        //   3. Absent from the server entirely: prune (resource was deleted or moved).
         if (existingTracking != null)
         {
-            var serverNames = filtered.Select(r => r.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var serverNames = listResult.Items.Select(r => r.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var inScopeNames = filtered.Select(r => r.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
             foreach (var (name, prior) in existingTracking.Resources)
             {
-                if (!serverNames.Contains(name)) continue; // pruned
-                if (newResourceEntries.ContainsKey(name)) continue; // already replaced
-                if (skippedNames.Contains(name))
+                if (newResourceEntries.ContainsKey(name)) continue; // already replaced by fresh entry
+                if (!serverNames.Contains(name)) continue;          // pruned (no longer on server)
+                if (inScopeNames.Contains(name))
                 {
+                    // In-scope and not freshly downloaded ⇒ skipped or errored ⇒ retain prior.
+                    newResourceEntries[name] = prior;
+                }
+                else
+                {
+                    // Out-of-scope (filtered out) ⇒ untouched by this pull ⇒ preserve prior entry.
                     newResourceEntries[name] = prior;
                 }
             }
@@ -252,6 +279,7 @@ public class WebResourceSyncService : IWebResourceSyncService
         }
 
         var skipped = new List<SkippedResource>();
+        var errors = new List<ErrorResource>();
         var pendingUpload = new List<(string Name, TrackedResource Tracked, string AbsolutePath, string Content)>();
 
         // Phase 1: detect local modifications (hash compare). Build the set of upload candidates.
@@ -284,14 +312,15 @@ public class WebResourceSyncService : IWebResourceSyncService
             pendingUpload.Add((name, entry, absolutePath, content));
         }
 
-        // Phase 2: server modifiedOn check (parallel, R2).
+        // Phase 2: server modifiedOn check (parallel, R2). Per-item failures are recorded so a
+        // single transient error does not abort the whole push (D4 — wrap, don't propagate raw).
         progress?.ReportStatus($"Checking {pendingUpload.Count} resource(s) for server conflicts...");
         var conflicts = new List<ConflictResource>();
         if (!options.Force && pendingUpload.Count > 0)
         {
             using var conflictSemaphore = new SemaphoreSlim(DefaultUploadParallelism);
             var serverModifiedOnByName = new Dictionary<string, DateTime?>();
-            var lockObj = new object();
+            var fetchLock = new object();
 
             async Task FetchOneAsync((string Name, TrackedResource Tracked, string AbsolutePath, string Content) item)
             {
@@ -299,9 +328,17 @@ public class WebResourceSyncService : IWebResourceSyncService
                 try
                 {
                     var serverModified = await _webResourceService.GetModifiedOnAsync(item.Tracked.Id, cancellationToken);
-                    lock (lockObj)
+                    lock (fetchLock)
                     {
                         serverModifiedOnByName[item.Name] = serverModified;
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "Failed to query modifiedOn for web resource {Name}", item.Name);
+                    lock (fetchLock)
+                    {
+                        errors.Add(new ErrorResource(item.Name, ex.Message));
                     }
                 }
                 finally
@@ -311,6 +348,10 @@ public class WebResourceSyncService : IWebResourceSyncService
             }
 
             await Task.WhenAll(pendingUpload.Select(FetchOneAsync));
+
+            // Drop items whose conflict-check errored: don't upload without a baseline.
+            var erroredNames = errors.Select(e => e.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            pendingUpload = pendingUpload.Where(u => !erroredNames.Contains(u.Name)).ToList();
 
             foreach (var item in pendingUpload)
             {
@@ -328,6 +369,7 @@ public class WebResourceSyncService : IWebResourceSyncService
                     Pushed: [],
                     Conflicts: conflicts,
                     Skipped: skipped,
+                    Errors: errors,
                     DryRun: options.DryRun,
                     PublishedCount: 0);
             }
@@ -341,11 +383,14 @@ public class WebResourceSyncService : IWebResourceSyncService
                 Pushed: pushedDryRun,
                 Conflicts: [],
                 Skipped: skipped,
+                Errors: errors,
                 DryRun: true,
                 PublishedCount: 0);
         }
 
-        // Phase 3: parallel uploads (R2).
+        // Phase 3: parallel uploads (R2). Per-item exceptions are recorded so partial successes
+        // still flow into the tracking refresh below — otherwise tracking goes stale and the
+        // next push falsely flags successful uploads as conflicts.
         progress?.ReportStatus($"Uploading {pendingUpload.Count} resource(s)...");
         var pushed = new List<PushedResource>();
         var uploadedIds = new List<Guid>();
@@ -373,6 +418,14 @@ public class WebResourceSyncService : IWebResourceSyncService
                     progress?.ReportProgress(done, pendingUpload.Count, item.Name);
                 }
             }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Failed to upload web resource {Name}", item.Name);
+                lock (uploadLock)
+                {
+                    errors.Add(new ErrorResource(item.Name, ex.Message));
+                }
+            }
             finally
             {
                 uploadSemaphore.Release();
@@ -385,10 +438,21 @@ public class WebResourceSyncService : IWebResourceSyncService
         if (options.Publish && uploadedIds.Count > 0)
         {
             progress?.ReportStatus($"Publishing {uploadedIds.Count} resource(s)...");
-            publishedCount = await _webResourceService.PublishAsync(uploadedIds, cancellationToken);
+            try
+            {
+                publishedCount = await _webResourceService.PublishAsync(uploadedIds, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Record but do not throw — successful uploads still need tracking refresh.
+                _logger.LogWarning(ex, "Publish failed for {Count} uploaded web resource(s)", uploadedIds.Count);
+                errors.Add(new ErrorResource("(publish)", ex.Message));
+            }
         }
 
-        // Phase 4: refresh tracking — re-query modifiedOn for uploaded resources, swap in new hashes.
+        // Phase 4: refresh tracking — re-query modifiedOn for uploaded resources, swap in new
+        // hashes. Per-item refresh failures fall back to the prior tracked modifiedOn so the
+        // tracking file at least stays consistent with what we sent.
         if (uploadedIds.Count > 0)
         {
             using var refreshSemaphore = new SemaphoreSlim(DefaultUploadParallelism);
@@ -406,6 +470,14 @@ public class WebResourceSyncService : IWebResourceSyncService
                         refreshedModifiedOn[kv.Key] = modified;
                     }
                 }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "Failed to refresh modifiedOn for {Name}", kv.Key);
+                    lock (refreshLock)
+                    {
+                        errors.Add(new ErrorResource(kv.Key, ex.Message));
+                    }
+                }
                 finally
                 {
                     refreshSemaphore.Release();
@@ -414,27 +486,39 @@ public class WebResourceSyncService : IWebResourceSyncService
 
             await Task.WhenAll(uploadedKeys.Select(RefreshOneAsync));
 
-            var updatedResources = new Dictionary<string, TrackedResource>(tracking.Resources, StringComparer.OrdinalIgnoreCase);
-            foreach (var (name, (_, tracked)) in uploadedKeys)
+            try
             {
-                var newHash = uploadedHashes[name];
-                refreshedModifiedOn.TryGetValue(name, out var newModified);
-                updatedResources[name] = tracked with
+                var updatedResources = new Dictionary<string, TrackedResource>(tracking.Resources, StringComparer.OrdinalIgnoreCase);
+                foreach (var (name, (_, tracked)) in uploadedKeys)
                 {
-                    Hash = newHash,
-                    ModifiedOn = newModified ?? tracked.ModifiedOn,
-                };
-            }
+                    var newHash = uploadedHashes[name];
+                    refreshedModifiedOn.TryGetValue(name, out var newModified);
+                    updatedResources[name] = tracked with
+                    {
+                        Hash = newHash,
+                        ModifiedOn = newModified ?? tracked.ModifiedOn,
+                    };
+                }
 
-            var updatedTracking = tracking with { Resources = updatedResources };
-            await WebResourceTrackingFile.WriteAsync(rootAbsolute, updatedTracking, cancellationToken);
+                var updatedTracking = tracking with { Resources = updatedResources };
+                await WebResourceTrackingFile.WriteAsync(rootAbsolute, updatedTracking, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Tracking write failed after successful uploads — surface as a structured error.
+                throw new PpdsException(
+                    ErrorCodes.Operation.PartialFailure,
+                    $"Uploaded {pushed.Count} resource(s) but failed to update the local tracking file. The next push may falsely detect a conflict; re-run 'ppds webresources pull' to recover.",
+                    ex);
+            }
         }
 
-        progress?.ReportComplete($"Pushed {pushed.Count} resource(s) ({skipped.Count} skipped)");
+        progress?.ReportComplete($"Pushed {pushed.Count} resource(s) ({skipped.Count} skipped, {errors.Count} errors)");
         return new PushResult(
             Pushed: pushed,
             Conflicts: [],
             Skipped: skipped,
+            Errors: errors,
             DryRun: false,
             PublishedCount: publishedCount);
     }
@@ -460,12 +544,25 @@ public class WebResourceSyncService : IWebResourceSyncService
     {
         var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var normalizedCandidate = candidate;
-        if (string.Equals(normalizedCandidate, normalizedRoot, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(normalizedCandidate, normalizedRoot, PathComparison))
         {
             return true;
         }
         var prefix = normalizedRoot + Path.DirectorySeparatorChar;
-        return normalizedCandidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+        return normalizedCandidate.StartsWith(prefix, PathComparison);
+    }
+
+    /// <summary>
+    /// Rejects names that could resolve to a path outside the workspace even before
+    /// <see cref="ComputeLocalPath"/> normalizes them — drive letters, UNC prefixes, rooted paths.
+    /// </summary>
+    private static bool IsUnsafeResourceName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return true;
+        if (name.Contains(':')) return true;            // C:\evil, file://...
+        if (name.Contains(@"\\")) return true;          // UNC \\server\share
+        if (Path.IsPathRooted(name)) return true;       // /etc/passwd on POSIX, etc.
+        return false;
     }
 
     private static string ComputeLocalPath(string resourceName, bool stripPrefix, string fileExtension)
@@ -502,7 +599,8 @@ public class WebResourceSyncService : IWebResourceSyncService
 
     private static string SanitizeName(string name)
     {
-        // Defense in depth: collapse leading separators, reject obvious traversal attempts.
+        // Defense in depth: collapse leading separators. Names with rooted/UNC/drive-letter
+        // forms are rejected upstream by IsUnsafeResourceName.
         return name.TrimStart('/', '\\');
     }
 }

--- a/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
@@ -75,11 +75,12 @@ public class WebResourceSyncService : IWebResourceSyncService
         // Per-resource path resolution + traversal validation up front so we can
         // skip downloads for invalid entries without occupying a download slot.
         var processable = new List<(WebResourceInfo Resource, string LocalPath, string AbsolutePath)>();
+        var pathClaims = new Dictionary<string, string>(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         foreach (var resource in filtered)
         {
             if (IsUnsafeResourceName(resource.Name))
             {
-                errors.Add(new ErrorResource(resource.Name, ErrorCodes.Validation.PathOutsideWorkspace));
+                errors.Add(new ErrorResource(resource.Name, "name resolves outside target folder"));
                 continue;
             }
 
@@ -87,9 +88,21 @@ public class WebResourceSyncService : IWebResourceSyncService
             var absolutePath = Path.GetFullPath(Path.Combine(rootAbsolute, localPath));
             if (!IsDescendantOf(absolutePath, rootAbsolute))
             {
-                errors.Add(new ErrorResource(resource.Name, ErrorCodes.Validation.PathOutsideWorkspace));
+                errors.Add(new ErrorResource(resource.Name, "name resolves outside target folder"));
                 continue;
             }
+
+            // Strip-prefix can collapse different publisher prefixes to the same
+            // local path (e.g. new_/scripts/app.js and dev_/scripts/app.js both
+            // become scripts/app.js). Refuse to write the second-and-later
+            // claimants rather than silently overwriting.
+            if (pathClaims.TryGetValue(absolutePath, out var firstClaimant))
+            {
+                errors.Add(new ErrorResource(resource.Name, $"local path collides with '{firstClaimant}' (omit --strip-prefix or narrow with --solution)"));
+                continue;
+            }
+            pathClaims[absolutePath] = resource.Name;
+
             processable.Add((resource, localPath, absolutePath));
         }
 

--- a/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
@@ -1,0 +1,493 @@
+using Microsoft.Extensions.Logging;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+
+namespace PPDS.Cli.Services.WebResources;
+
+/// <summary>
+/// Orchestrates pull and push between Dataverse web resources and a local folder.
+/// Composes <see cref="IWebResourceService"/> for Dataverse CRUD and manages the
+/// local <see cref="WebResourceTrackingFile"/>.
+/// </summary>
+public class WebResourceSyncService : IWebResourceSyncService
+{
+    private const int DefaultDownloadParallelism = 8;
+    private const int DefaultUploadParallelism = 4;
+
+    private readonly IWebResourceService _webResourceService;
+    private readonly ILogger<WebResourceSyncService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebResourceSyncService"/> class.
+    /// </summary>
+    public WebResourceSyncService(
+        IWebResourceService webResourceService,
+        ILogger<WebResourceSyncService> logger)
+    {
+        _webResourceService = webResourceService ?? throw new ArgumentNullException(nameof(webResourceService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<PullResult> PullAsync(PullOptions options, IOperationProgress? progress, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        progress?.ReportStatus("Listing web resources...");
+        var listResult = await _webResourceService.ListAsync(
+            solutionId: options.SolutionId,
+            textOnly: false,
+            cancellationToken: cancellationToken);
+
+        var totalServerCount = listResult.TotalCount;
+        var resources = (IEnumerable<WebResourceInfo>)listResult.Items;
+
+        if (options.TypeCodes is { Length: > 0 } typeCodes)
+        {
+            resources = resources.Where(r => typeCodes.Contains(r.WebResourceType));
+        }
+
+        if (!string.IsNullOrEmpty(options.NamePattern))
+        {
+            resources = resources.Where(r => r.Name.Contains(options.NamePattern, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var filtered = resources.ToList();
+
+        // Resolve absolute folder path once for traversal checks
+        var rootAbsolute = Path.GetFullPath(options.Folder);
+        Directory.CreateDirectory(rootAbsolute);
+
+        var existingTracking = options.Force
+            ? null
+            : await WebResourceTrackingFile.ReadAsync(rootAbsolute, cancellationToken);
+
+        var pulled = new List<PulledResource>();
+        var skipped = new List<SkippedResource>();
+        var errors = new List<ErrorResource>();
+        var newResourceEntries = new Dictionary<string, TrackedResource>(StringComparer.OrdinalIgnoreCase);
+
+        // Per-resource path resolution + traversal validation up front so we can
+        // skip downloads for invalid entries without occupying a download slot.
+        var processable = new List<(WebResourceInfo Resource, string LocalPath, string AbsolutePath)>();
+        foreach (var resource in filtered)
+        {
+            var localPath = ComputeLocalPath(resource.Name, options.StripPrefix, resource.FileExtension);
+            var absolutePath = Path.GetFullPath(Path.Combine(rootAbsolute, localPath));
+            if (!IsDescendantOf(absolutePath, rootAbsolute))
+            {
+                errors.Add(new ErrorResource(resource.Name, ErrorCodes.Validation.PathOutsideWorkspace));
+                continue;
+            }
+            processable.Add((resource, localPath, absolutePath));
+        }
+
+        // Local-modification check (skip when --force)
+        var toDownload = new List<(WebResourceInfo Resource, string LocalPath, string AbsolutePath, bool IsNew)>();
+        foreach (var (resource, localPath, absolutePath) in processable)
+        {
+            if (!resource.IsTextType)
+            {
+                // Binary types: record metadata in tracking file but do not download.
+                skipped.Add(new SkippedResource(resource.Name, "binary type"));
+                continue;
+            }
+
+            var existsLocally = File.Exists(absolutePath);
+            if (existingTracking != null && existsLocally && existingTracking.Resources.TryGetValue(resource.Name, out var prior))
+            {
+                var localHash = await WebResourceTrackingFile.ComputeHashAsync(absolutePath, cancellationToken);
+                if (!string.Equals(localHash, prior.Hash, StringComparison.OrdinalIgnoreCase))
+                {
+                    skipped.Add(new SkippedResource(resource.Name, "locally modified"));
+                    continue;
+                }
+            }
+
+            toDownload.Add((resource, localPath, absolutePath, !existsLocally));
+        }
+
+        // Parallel download with throttling and CancellationToken propagation (R2)
+        var totalToDownload = toDownload.Count;
+        progress?.ReportStatus($"Downloading {totalToDownload} resource(s)...");
+        using var semaphore = new SemaphoreSlim(DefaultDownloadParallelism);
+        var completed = 0;
+        var pulledLock = new object();
+
+        async Task DownloadOneAsync((WebResourceInfo Resource, string LocalPath, string AbsolutePath, bool IsNew) item)
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var (resource, localPath, absolutePath, isNew) = item;
+                var content = await _webResourceService.GetContentAsync(resource.Id, published: false, cancellationToken);
+                if (content?.Content == null)
+                {
+                    lock (pulledLock)
+                    {
+                        skipped.Add(new SkippedResource(resource.Name, "no content"));
+                    }
+                    return;
+                }
+
+                var directory = Path.GetDirectoryName(absolutePath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                await File.WriteAllTextAsync(absolutePath, content.Content, cancellationToken);
+                var hash = await WebResourceTrackingFile.ComputeHashAsync(absolutePath, cancellationToken);
+
+                lock (pulledLock)
+                {
+                    pulled.Add(new PulledResource(resource.Name, localPath, isNew));
+                    newResourceEntries[resource.Name] = new TrackedResource(
+                        resource.Id,
+                        content.ModifiedOn ?? resource.ModifiedOn,
+                        hash,
+                        localPath,
+                        resource.WebResourceType);
+                    var done = Interlocked.Increment(ref completed);
+                    progress?.ReportProgress(done, totalToDownload, resource.Name);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Failed to download web resource {Name}", item.Resource.Name);
+                lock (pulledLock)
+                {
+                    errors.Add(new ErrorResource(item.Resource.Name, ex.Message));
+                }
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        await Task.WhenAll(toDownload.Select(DownloadOneAsync));
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Record binary resources in tracking even though we did not download content.
+        // Hash for binary entries is empty — push will skip these regardless.
+        foreach (var (resource, localPath, _) in processable)
+        {
+            if (resource.IsTextType) continue;
+            if (newResourceEntries.ContainsKey(resource.Name)) continue;
+            newResourceEntries[resource.Name] = new TrackedResource(
+                resource.Id,
+                resource.ModifiedOn,
+                Hash: string.Empty,
+                localPath,
+                resource.WebResourceType);
+        }
+
+        // Merge: locally modified (skipped) entries retain prior tracking; resources no longer
+        // returned by the server are pruned. Errored entries also retain prior tracking when present.
+        var skippedNames = skipped.Select(s => s.Name)
+            .Concat(errors.Select(e => e.Name))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (existingTracking != null)
+        {
+            var serverNames = filtered.Select(r => r.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, prior) in existingTracking.Resources)
+            {
+                if (!serverNames.Contains(name)) continue; // pruned
+                if (newResourceEntries.ContainsKey(name)) continue; // already replaced
+                if (skippedNames.Contains(name))
+                {
+                    newResourceEntries[name] = prior;
+                }
+            }
+        }
+
+        var trackingFile = new WebResourceTrackingFile(
+            Version: WebResourceTrackingFile.CurrentVersion,
+            EnvironmentUrl: options.EnvironmentUrl,
+            Solution: options.SolutionUniqueName,
+            StripPrefix: options.StripPrefix,
+            PulledAt: DateTime.UtcNow,
+            Resources: newResourceEntries);
+
+        await WebResourceTrackingFile.WriteAsync(rootAbsolute, trackingFile, cancellationToken);
+        progress?.ReportComplete($"Pulled {pulled.Count} of {totalServerCount} resource(s) ({skipped.Count} skipped, {errors.Count} errors)");
+
+        return new PullResult(totalServerCount, pulled, skipped, errors);
+    }
+
+    /// <inheritdoc />
+    public async Task<PushResult> PushAsync(PushOptions options, IOperationProgress? progress, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var rootAbsolute = Path.GetFullPath(options.Folder);
+        var tracking = await WebResourceTrackingFile.ReadAsync(rootAbsolute, cancellationToken)
+            ?? throw new PpdsException(
+                ErrorCodes.Validation.FileNotFound,
+                $"Tracking file '{WebResourceTrackingFile.TrackingFileRelativePath}' not found in '{options.Folder}'. Run 'ppds webresources pull' first.");
+
+        if (!options.Force && !UrlsEqual(tracking.EnvironmentUrl, options.CurrentEnvironmentUrl))
+        {
+            throw new PpdsException(
+                ErrorCodes.Connection.InvalidEnvironmentUrl,
+                $"Environment mismatch: connected to '{options.CurrentEnvironmentUrl}' but tracking file was created from '{tracking.EnvironmentUrl}'. Use --force to override.");
+        }
+
+        var skipped = new List<SkippedResource>();
+        var pendingUpload = new List<(string Name, TrackedResource Tracked, string AbsolutePath, string Content)>();
+
+        // Phase 1: detect local modifications (hash compare). Build the set of upload candidates.
+        foreach (var (name, entry) in tracking.Resources)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsTextType(entry.WebResourceType))
+            {
+                skipped.Add(new SkippedResource(name, "binary type (read-only)"));
+                continue;
+            }
+
+            var absolutePath = Path.GetFullPath(Path.Combine(rootAbsolute, entry.LocalPath));
+            if (!File.Exists(absolutePath))
+            {
+                _logger.LogWarning("Tracked file missing from disk: {Path}", absolutePath);
+                skipped.Add(new SkippedResource(name, "file deleted"));
+                continue;
+            }
+
+            var localHash = await WebResourceTrackingFile.ComputeHashAsync(absolutePath, cancellationToken);
+            if (string.Equals(localHash, entry.Hash, StringComparison.OrdinalIgnoreCase))
+            {
+                skipped.Add(new SkippedResource(name, "unchanged"));
+                continue;
+            }
+
+            var content = await File.ReadAllTextAsync(absolutePath, cancellationToken);
+            pendingUpload.Add((name, entry, absolutePath, content));
+        }
+
+        // Phase 2: server modifiedOn check (parallel, R2).
+        progress?.ReportStatus($"Checking {pendingUpload.Count} resource(s) for server conflicts...");
+        var conflicts = new List<ConflictResource>();
+        if (!options.Force && pendingUpload.Count > 0)
+        {
+            using var conflictSemaphore = new SemaphoreSlim(DefaultUploadParallelism);
+            var serverModifiedOnByName = new Dictionary<string, DateTime?>();
+            var lockObj = new object();
+
+            async Task FetchOneAsync((string Name, TrackedResource Tracked, string AbsolutePath, string Content) item)
+            {
+                await conflictSemaphore.WaitAsync(cancellationToken);
+                try
+                {
+                    var serverModified = await _webResourceService.GetModifiedOnAsync(item.Tracked.Id, cancellationToken);
+                    lock (lockObj)
+                    {
+                        serverModifiedOnByName[item.Name] = serverModified;
+                    }
+                }
+                finally
+                {
+                    conflictSemaphore.Release();
+                }
+            }
+
+            await Task.WhenAll(pendingUpload.Select(FetchOneAsync));
+
+            foreach (var item in pendingUpload)
+            {
+                if (serverModifiedOnByName.TryGetValue(item.Name, out var serverModified)
+                    && !ModifiedOnEqual(serverModified, item.Tracked.ModifiedOn))
+                {
+                    conflicts.Add(new ConflictResource(item.Name, item.Tracked.ModifiedOn, serverModified));
+                }
+            }
+
+            if (conflicts.Count > 0)
+            {
+                // All-or-nothing: do not push when conflicts exist.
+                return new PushResult(
+                    Pushed: [],
+                    Conflicts: conflicts,
+                    Skipped: skipped,
+                    DryRun: options.DryRun,
+                    PublishedCount: 0);
+            }
+        }
+
+        if (options.DryRun)
+        {
+            var pushedDryRun = pendingUpload.Select(u => new PushedResource(u.Name, u.Tracked.LocalPath)).ToList();
+            progress?.ReportComplete($"Dry run: would push {pushedDryRun.Count} resource(s) ({skipped.Count} skipped)");
+            return new PushResult(
+                Pushed: pushedDryRun,
+                Conflicts: [],
+                Skipped: skipped,
+                DryRun: true,
+                PublishedCount: 0);
+        }
+
+        // Phase 3: parallel uploads (R2).
+        progress?.ReportStatus($"Uploading {pendingUpload.Count} resource(s)...");
+        var pushed = new List<PushedResource>();
+        var uploadedIds = new List<Guid>();
+        var uploadedHashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var uploadedKeys = new Dictionary<string, (string Name, TrackedResource Tracked)>(StringComparer.OrdinalIgnoreCase);
+        var uploadCompleted = 0;
+        var uploadLock = new object();
+
+        using var uploadSemaphore = new SemaphoreSlim(DefaultUploadParallelism);
+
+        async Task UploadOneAsync((string Name, TrackedResource Tracked, string AbsolutePath, string Content) item)
+        {
+            await uploadSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                await _webResourceService.UpdateContentAsync(item.Tracked.Id, item.Content, cancellationToken);
+                var newHash = await WebResourceTrackingFile.ComputeHashAsync(item.AbsolutePath, cancellationToken);
+                lock (uploadLock)
+                {
+                    pushed.Add(new PushedResource(item.Name, item.Tracked.LocalPath));
+                    uploadedIds.Add(item.Tracked.Id);
+                    uploadedHashes[item.Name] = newHash;
+                    uploadedKeys[item.Name] = (item.Name, item.Tracked);
+                    var done = Interlocked.Increment(ref uploadCompleted);
+                    progress?.ReportProgress(done, pendingUpload.Count, item.Name);
+                }
+            }
+            finally
+            {
+                uploadSemaphore.Release();
+            }
+        }
+
+        await Task.WhenAll(pendingUpload.Select(UploadOneAsync));
+
+        var publishedCount = 0;
+        if (options.Publish && uploadedIds.Count > 0)
+        {
+            progress?.ReportStatus($"Publishing {uploadedIds.Count} resource(s)...");
+            publishedCount = await _webResourceService.PublishAsync(uploadedIds, cancellationToken);
+        }
+
+        // Phase 4: refresh tracking — re-query modifiedOn for uploaded resources, swap in new hashes.
+        if (uploadedIds.Count > 0)
+        {
+            using var refreshSemaphore = new SemaphoreSlim(DefaultUploadParallelism);
+            var refreshedModifiedOn = new Dictionary<string, DateTime?>();
+            var refreshLock = new object();
+
+            async Task RefreshOneAsync(KeyValuePair<string, (string Name, TrackedResource Tracked)> kv)
+            {
+                await refreshSemaphore.WaitAsync(cancellationToken);
+                try
+                {
+                    var modified = await _webResourceService.GetModifiedOnAsync(kv.Value.Tracked.Id, cancellationToken);
+                    lock (refreshLock)
+                    {
+                        refreshedModifiedOn[kv.Key] = modified;
+                    }
+                }
+                finally
+                {
+                    refreshSemaphore.Release();
+                }
+            }
+
+            await Task.WhenAll(uploadedKeys.Select(RefreshOneAsync));
+
+            var updatedResources = new Dictionary<string, TrackedResource>(tracking.Resources, StringComparer.OrdinalIgnoreCase);
+            foreach (var (name, (_, tracked)) in uploadedKeys)
+            {
+                var newHash = uploadedHashes[name];
+                refreshedModifiedOn.TryGetValue(name, out var newModified);
+                updatedResources[name] = tracked with
+                {
+                    Hash = newHash,
+                    ModifiedOn = newModified ?? tracked.ModifiedOn,
+                };
+            }
+
+            var updatedTracking = tracking with { Resources = updatedResources };
+            await WebResourceTrackingFile.WriteAsync(rootAbsolute, updatedTracking, cancellationToken);
+        }
+
+        progress?.ReportComplete($"Pushed {pushed.Count} resource(s) ({skipped.Count} skipped)");
+        return new PushResult(
+            Pushed: pushed,
+            Conflicts: [],
+            Skipped: skipped,
+            DryRun: false,
+            PublishedCount: publishedCount);
+    }
+
+    private static bool IsTextType(int code) => code is 1 or 2 or 3 or 4 or 9 or 11 or 12;
+
+    private static bool ModifiedOnEqual(DateTime? a, DateTime? b)
+    {
+        if (a is null && b is null) return true;
+        if (a is null || b is null) return false;
+        // Allow sub-second drift introduced by serialization round-trips.
+        return Math.Abs((a.Value - b.Value).TotalMilliseconds) < 1;
+    }
+
+    private static bool UrlsEqual(string? a, string? b)
+    {
+        if (string.IsNullOrEmpty(a) && string.IsNullOrEmpty(b)) return true;
+        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return false;
+        return string.Equals(a.TrimEnd('/'), b.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDescendantOf(string candidate, string root)
+    {
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedCandidate = candidate;
+        if (string.Equals(normalizedCandidate, normalizedRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        var prefix = normalizedRoot + Path.DirectorySeparatorChar;
+        return normalizedCandidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ComputeLocalPath(string resourceName, bool stripPrefix, string fileExtension)
+    {
+        var sanitized = SanitizeName(resourceName);
+
+        if (stripPrefix)
+        {
+            // Pattern: <prefix>_<rest> at the start, e.g. new_/scripts/app.js → scripts/app.js
+            // Detect by looking for the first '_' before the first '/'.
+            var firstSlash = sanitized.IndexOf('/');
+            if (firstSlash > 0)
+            {
+                var prefixSegment = sanitized[..firstSlash];
+                var underscore = prefixSegment.IndexOf('_');
+                if (underscore >= 0)
+                {
+                    sanitized = sanitized[(underscore + 1)..];
+                    if (sanitized.StartsWith('/'))
+                    {
+                        sanitized = sanitized[1..];
+                    }
+                }
+            }
+        }
+
+        if (!Path.HasExtension(sanitized))
+        {
+            sanitized += "." + fileExtension;
+        }
+
+        return sanitized.Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    private static string SanitizeName(string name)
+    {
+        // Defense in depth: collapse leading separators, reject obvious traversal attempts.
+        return name.TrimStart('/', '\\');
+    }
+}

--- a/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceSyncService.cs
@@ -14,10 +14,15 @@ public class WebResourceSyncService : IWebResourceSyncService
     private const int DefaultDownloadParallelism = 8;
     private const int DefaultUploadParallelism = 4;
 
-    // Path comparisons must be case-sensitive on POSIX, case-insensitive on Windows.
-    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+    // Path comparisons must be case-insensitive on Windows and macOS (default APFS/HFS+ are
+    // case-insensitive), case-sensitive on Linux/other POSIX.
+    private static readonly bool PathsAreCaseInsensitive = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+    private static readonly StringComparison PathComparison = PathsAreCaseInsensitive
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
+    private static readonly StringComparer PathComparer = PathsAreCaseInsensitive
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
 
     private readonly IWebResourceService _webResourceService;
     private readonly ILogger<WebResourceSyncService> _logger;
@@ -75,7 +80,7 @@ public class WebResourceSyncService : IWebResourceSyncService
         // Per-resource path resolution + traversal validation up front so we can
         // skip downloads for invalid entries without occupying a download slot.
         var processable = new List<(WebResourceInfo Resource, string LocalPath, string AbsolutePath)>();
-        var pathClaims = new Dictionary<string, string>(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        var pathClaims = new Dictionary<string, string>(PathComparer);
         foreach (var resource in filtered)
         {
             if (IsUnsafeResourceName(resource.Name))

--- a/src/PPDS.Cli/Services/WebResources/WebResourceTrackingFile.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceTrackingFile.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Cli.Services.WebResources;
+
+/// <summary>
+/// Local tracking file written to <c>&lt;folder&gt;/.ppds/webresources.json</c>
+/// after a pull operation. Used by push to detect local edits and server conflicts.
+/// </summary>
+/// <param name="Version">Schema version for forward compatibility.</param>
+/// <param name="EnvironmentUrl">Environment URL the resources were pulled from.</param>
+/// <param name="Solution">Solution unique name used as filter (null if unfiltered).</param>
+/// <param name="StripPrefix">Whether publisher prefix was stripped from local paths.</param>
+/// <param name="PulledAt">UTC timestamp of the pull operation.</param>
+/// <param name="Resources">Map keyed by Dataverse web resource name.</param>
+public sealed record WebResourceTrackingFile(
+    int Version,
+    string EnvironmentUrl,
+    string? Solution,
+    bool StripPrefix,
+    DateTime PulledAt,
+    IReadOnlyDictionary<string, TrackedResource> Resources)
+{
+    /// <summary>The relative tracking-file path within the target folder.</summary>
+    public const string TrackingFileRelativePath = ".ppds/webresources.json";
+
+    /// <summary>Current schema version.</summary>
+    public const int CurrentVersion = 1;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DictionaryKeyPolicy = null,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Reads the tracking file from the target folder. Returns null if the file does not exist.
+    /// </summary>
+    public static async Task<WebResourceTrackingFile?> ReadAsync(string folder, CancellationToken cancellationToken = default)
+    {
+        var path = Path.Combine(folder, TrackingFileRelativePath);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        await using var stream = File.OpenRead(path);
+        return await JsonSerializer.DeserializeAsync<WebResourceTrackingFile>(stream, SerializerOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Writes the tracking file to the target folder, creating the <c>.ppds</c> subdirectory if needed.
+    /// </summary>
+    public static async Task WriteAsync(string folder, WebResourceTrackingFile trackingFile, CancellationToken cancellationToken = default)
+    {
+        var path = Path.Combine(folder, TrackingFileRelativePath);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var stream = File.Create(path);
+        await JsonSerializer.SerializeAsync(stream, trackingFile, SerializerOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Computes a SHA256 hash of the file's bytes, formatted as <c>sha256:&lt;hex&gt;</c>.
+    /// Operates on raw bytes so the hash is platform- and line-ending-independent.
+    /// </summary>
+    public static async Task<string> ComputeHashAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        await using var stream = File.OpenRead(filePath);
+        using var sha = SHA256.Create();
+        var hash = await sha.ComputeHashAsync(stream, cancellationToken);
+        return "sha256:" + Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+/// <summary>
+/// Per-resource tracking entry recorded by pull and consumed by push.
+/// </summary>
+/// <param name="Id">The Dataverse web resource GUID.</param>
+/// <param name="ModifiedOn">The server's <c>modifiedon</c> at pull time. Conflict-detection baseline.</param>
+/// <param name="Hash">SHA256 hash of the local file content at pull time, in <c>sha256:&lt;hex&gt;</c> format.</param>
+/// <param name="LocalPath">Path relative to the folder root (may differ from <c>name</c> if prefix stripped).</param>
+/// <param name="WebResourceType">The Dataverse web resource type code (1-12).</param>
+public sealed record TrackedResource(
+    Guid Id,
+    DateTime? ModifiedOn,
+    string Hash,
+    string LocalPath,
+    int WebResourceType);

--- a/src/PPDS.Cli/Services/WebResources/WebResourceTrackingFile.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceTrackingFile.cs
@@ -49,9 +49,18 @@ public sealed record WebResourceTrackingFile(
         }
 
         WebResourceTrackingFile? deserialized;
-        await using (var stream = File.OpenRead(path))
+        try
         {
+            await using var stream = File.OpenRead(path);
             deserialized = await JsonSerializer.DeserializeAsync<WebResourceTrackingFile>(stream, SerializerOptions, cancellationToken);
+        }
+        catch (JsonException ex)
+        {
+            // Don't leak internal type names from System.Text.Json into user-facing output.
+            throw new PpdsException(
+                ErrorCodes.Validation.SchemaInvalid,
+                $"Tracking file '{TrackingFileRelativePath}' in '{folder}' is corrupt or malformed. Re-run 'ppds webresources pull {folder}' to recreate it.",
+                ex);
         }
 
         if (deserialized is null)
@@ -70,7 +79,7 @@ public sealed record WebResourceTrackingFile(
         {
             throw new PpdsException(
                 ErrorCodes.Validation.SchemaInvalid,
-                $"Tracking file schema version {deserialized.Version} is invalid. Expected version 1 or later.");
+                $"Tracking file '{TrackingFileRelativePath}' in '{folder}' is missing or has an invalid 'version' field (expected 1). Re-run 'ppds webresources pull {folder}' to recreate it.");
         }
 
         // Rebuild Resources with OrdinalIgnoreCase so lookups match the comparer used at pull time.

--- a/src/PPDS.Cli/Services/WebResources/WebResourceTrackingFile.cs
+++ b/src/PPDS.Cli/Services/WebResources/WebResourceTrackingFile.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using PPDS.Cli.Infrastructure.Errors;
 
 namespace PPDS.Cli.Services.WebResources;
 
@@ -47,8 +48,34 @@ public sealed record WebResourceTrackingFile(
             return null;
         }
 
-        await using var stream = File.OpenRead(path);
-        return await JsonSerializer.DeserializeAsync<WebResourceTrackingFile>(stream, SerializerOptions, cancellationToken);
+        WebResourceTrackingFile? deserialized;
+        await using (var stream = File.OpenRead(path))
+        {
+            deserialized = await JsonSerializer.DeserializeAsync<WebResourceTrackingFile>(stream, SerializerOptions, cancellationToken);
+        }
+
+        if (deserialized is null)
+        {
+            return null;
+        }
+
+        if (deserialized.Version > CurrentVersion)
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.SchemaInvalid,
+                $"Tracking file schema version {deserialized.Version} is newer than supported version {CurrentVersion}. Update the PPDS CLI.");
+        }
+
+        if (deserialized.Version < 1)
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.SchemaInvalid,
+                $"Tracking file schema version {deserialized.Version} is invalid. Expected version 1 or later.");
+        }
+
+        // Rebuild Resources with OrdinalIgnoreCase so lookups match the comparer used at pull time.
+        var resources = new Dictionary<string, TrackedResource>(deserialized.Resources, StringComparer.OrdinalIgnoreCase);
+        return deserialized with { Resources = resources };
     }
 
     /// <summary>
@@ -63,8 +90,23 @@ public sealed record WebResourceTrackingFile(
             Directory.CreateDirectory(directory);
         }
 
-        await using var stream = File.Create(path);
-        await JsonSerializer.SerializeAsync(stream, trackingFile, SerializerOptions, cancellationToken);
+        // Atomic write: serialize to a sibling .tmp file then rename, so a crash
+        // mid-serialize cannot leave the canonical tracking file truncated or corrupt.
+        var tempPath = path + ".tmp";
+        try
+        {
+            await using (var stream = File.Create(tempPath))
+            {
+                await JsonSerializer.SerializeAsync(stream, trackingFile, SerializerOptions, cancellationToken);
+            }
+
+            File.Move(tempPath, path, overwrite: true);
+        }
+        catch
+        {
+            try { File.Delete(tempPath); } catch { /* best effort */ }
+            throw;
+        }
     }
 
     /// <summary>

--- a/tests/PPDS.Cli.Tests/Commands/WebResources/PullCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/WebResources/PullCommandTests.cs
@@ -1,0 +1,44 @@
+using System.CommandLine;
+using FluentAssertions;
+using PPDS.Cli.Commands.WebResources;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.WebResources;
+
+public class PullCommandTests
+{
+    private readonly Command _command = PullCommand.Create();
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        _command.Name.Should().Be("pull");
+    }
+
+    [Fact]
+    public void Create_HasFolderArgument()
+    {
+        _command.Arguments.Should().ContainSingle();
+        _command.Arguments[0].Name.Should().Be("folder");
+    }
+
+    [Theory]
+    [InlineData("--solution")]
+    [InlineData("--type")]
+    [InlineData("--name")]
+    [InlineData("--strip-prefix")]
+    [InlineData("--force")]
+    [InlineData("--profile")]
+    [InlineData("--environment")]
+    public void Create_HasOption(string optionName)
+    {
+        _command.Options.Should().Contain(o => o.Name == optionName);
+    }
+
+    [Fact]
+    public void Create_RegisteredInWebResourcesCommandGroup()
+    {
+        var group = WebResourcesCommandGroup.Create();
+        group.Subcommands.Should().Contain(c => c.Name == "pull");
+    }
+}

--- a/tests/PPDS.Cli.Tests/Commands/WebResources/PushCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/WebResources/PushCommandTests.cs
@@ -17,10 +17,10 @@ public class PushCommandTests
     }
 
     [Fact]
-    public void Create_HasPathArgument()
+    public void Create_HasFolderArgument()
     {
         _command.Arguments.Should().ContainSingle();
-        _command.Arguments[0].Name.Should().Be("path");
+        _command.Arguments[0].Name.Should().Be("folder");
     }
 
     [Theory]

--- a/tests/PPDS.Cli.Tests/Commands/WebResources/PushCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/WebResources/PushCommandTests.cs
@@ -42,11 +42,12 @@ public class PushCommandTests
     }
 
     /// <summary>
-    /// AC-WR-42: tracking-file-not-found surfaces as exit-code NotFoundError (6) via ExceptionMapper
-    /// when PpdsException's ErrorCode is Validation.FileNotFound.
+    /// AC-WR-42: tracking-file-not-found PpdsException (ErrorCode = Validation.FileNotFound)
+    /// is mapped by ExceptionMapper to the InvalidArguments (3) exit code — i.e., the user
+    /// pointed `push` at a folder that hasn't been pulled.
     /// </summary>
     [Fact]
-    public void PushErrorsOnMissingTrackingFile_MapsToNotFoundExitCode()
+    public void PushErrorsOnMissingTrackingFile_MapsToInvalidArgumentsExitCode()
     {
         var ex = new PpdsException(
             ErrorCodes.Validation.FileNotFound,
@@ -71,6 +72,15 @@ public class PushCommandTests
 
         exitCode.Should().Be(ExitCodes.ConnectionError);
     }
+
+    // SUGGESTION: A true handler-level test would arrange a conflict via a mocked
+    // IWebResourceSyncService and assert the command returns ExitCodes.PreconditionFailed.
+    // Skipped because PushCommand.ExecuteAsync is private and constructs its service
+    // provider via ProfileServiceFactory.CreateFromProfilesAsync — there is no DI seam
+    // to inject a fake IWebResourceSyncService without modifying production code (out of
+    // scope for this fix pass). End-to-end conflict→ExitCode behavior is covered by
+    // WebResourceSyncServiceTests.PushDetectsServerConflict (verifies result.Conflicts is
+    // populated) plus the assertion below (verifies the constant the command branches on).
 
     /// <summary>
     /// AC-WR-44: PushResult with conflicts maps to PreconditionFailed (10).

--- a/tests/PPDS.Cli.Tests/Commands/WebResources/PushCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/WebResources/PushCommandTests.cs
@@ -1,0 +1,85 @@
+using System.CommandLine;
+using FluentAssertions;
+using PPDS.Cli.Commands.WebResources;
+using PPDS.Cli.Infrastructure.Errors;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.WebResources;
+
+public class PushCommandTests
+{
+    private readonly Command _command = PushCommand.Create();
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        _command.Name.Should().Be("push");
+    }
+
+    [Fact]
+    public void Create_HasPathArgument()
+    {
+        _command.Arguments.Should().ContainSingle();
+        _command.Arguments[0].Name.Should().Be("path");
+    }
+
+    [Theory]
+    [InlineData("--force")]
+    [InlineData("--dry-run")]
+    [InlineData("--publish")]
+    [InlineData("--profile")]
+    [InlineData("--environment")]
+    public void Create_HasOption(string optionName)
+    {
+        _command.Options.Should().Contain(o => o.Name == optionName);
+    }
+
+    [Fact]
+    public void Create_RegisteredInWebResourcesCommandGroup()
+    {
+        var group = WebResourcesCommandGroup.Create();
+        group.Subcommands.Should().Contain(c => c.Name == "push");
+    }
+
+    /// <summary>
+    /// AC-WR-42: tracking-file-not-found surfaces as exit-code NotFoundError (6) via ExceptionMapper
+    /// when PpdsException's ErrorCode is Validation.FileNotFound.
+    /// </summary>
+    [Fact]
+    public void PushErrorsOnMissingTrackingFile_MapsToNotFoundExitCode()
+    {
+        var ex = new PpdsException(
+            ErrorCodes.Validation.FileNotFound,
+            "Tracking file not found.");
+
+        var exitCode = ExceptionMapper.ToExitCode(ex);
+
+        exitCode.Should().Be(ExitCodes.InvalidArguments);
+    }
+
+    /// <summary>
+    /// AC-WR-52: environment-mismatch PpdsException maps to ConnectionError (4) exit code.
+    /// </summary>
+    [Fact]
+    public void PushErrorsOnEnvironmentMismatch_MapsToConnectionExitCode()
+    {
+        var ex = new PpdsException(
+            ErrorCodes.Connection.InvalidEnvironmentUrl,
+            "Environment mismatch.");
+
+        var exitCode = ExceptionMapper.ToExitCode(ex);
+
+        exitCode.Should().Be(ExitCodes.ConnectionError);
+    }
+
+    /// <summary>
+    /// AC-WR-44: PushResult with conflicts maps to PreconditionFailed (10).
+    /// Verifies the constant the command relies on; the command-level mapping is exercised
+    /// in WebResourceSyncServiceTests.PushDetectsServerConflict and asserted at the boundary.
+    /// </summary>
+    [Fact]
+    public void PushConflictReturnsExitCode10()
+    {
+        ExitCodes.PreconditionFailed.Should().Be(10);
+    }
+}

--- a/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceSyncServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceSyncServiceTests.cs
@@ -88,6 +88,13 @@ public class WebResourceSyncServiceTests : IDisposable
     }
 
     /// <summary>AC-WR-38: parallel downloads — multiple GetContentAsync calls observed concurrently.</summary>
+    // SUGGESTION: This already uses the deterministic counter pattern requested
+    // (FakeWebResourceService.GetContentAsync increments/decrements _currentParallel via
+    // Interlocked and tracks PeakConcurrency). The 80ms latency only ensures the in-flight
+    // window overlaps during the run; the assertion observes concurrency directly, not
+    // wall-clock time. BeGreaterThan(1) is the loosest claim we can make without coupling
+    // to thread-pool scheduling (the service's MaxParallelism is intentionally an upper
+    // bound, not a guarantee of how many slots fill at any instant on small inputs).
     [Fact]
     public async Task PullDownloadsInParallel()
     {
@@ -139,25 +146,31 @@ public class WebResourceSyncServiceTests : IDisposable
         (await File.ReadAllTextAsync(localFile)).Should().Be("server-side update");
     }
 
-    /// <summary>AC-WR-41: type-code and name-pattern filters apply in the service (Constitution A1).</summary>
+    /// <summary>AC-WR-41: type-code filter applies in the service (Constitution A1).</summary>
     [Fact]
-    public async Task PullFiltersResources()
+    public async Task PullFiltersByTypeCode()
     {
         _fake.AddText("new_/scripts/app.js", "x");      // type 3
         _fake.AddText("new_/scripts/util.js", "x");     // type 3
         _fake.AddText("new_/styles/site.css", "x", type: 2);
 
-        // Type filter only (only JS)
-        var jsResult = await _service.PullAsync(PullOpts(typeCodes: [3]), null);
-        jsResult.Pulled.Should().HaveCount(2);
+        var result = await _service.PullAsync(PullOpts(typeCodes: [3]), null);
 
-        // Reset state
-        Directory.Delete(_folder, recursive: true);
-        Directory.CreateDirectory(_folder);
+        result.Pulled.Should().HaveCount(2);
+        result.Pulled.Should().OnlyContain(p => p.Name.EndsWith(".js"));
+    }
 
-        // Name pattern only
-        var nameResult = await _service.PullAsync(PullOpts(namePattern: "util"), null);
-        nameResult.Pulled.Should().ContainSingle(p => p.Name == "new_/scripts/util.js");
+    /// <summary>AC-WR-41: name-pattern filter applies in the service (Constitution A1).</summary>
+    [Fact]
+    public async Task PullFiltersByNamePattern()
+    {
+        _fake.AddText("new_/scripts/app.js", "x");
+        _fake.AddText("new_/scripts/util.js", "x");
+        _fake.AddText("new_/styles/site.css", "x", type: 2);
+
+        var result = await _service.PullAsync(PullOpts(namePattern: "util"), null);
+
+        result.Pulled.Should().ContainSingle(p => p.Name == "new_/scripts/util.js");
     }
 
     /// <summary>AC-WR-51: resources whose computed path escapes the workspace are rejected.</summary>
@@ -292,6 +305,10 @@ public class WebResourceSyncServiceTests : IDisposable
 
         var result = await _service.PushAsync(PushOpts(publish: true), null);
 
+        // Make precision-loss bugs in tracking-file ModifiedOn round-trip fail visibly:
+        // if any conflict were spuriously detected, the affected resource would not be uploaded
+        // and the publish counts below would silently disagree with intent.
+        result.Conflicts.Should().BeEmpty();
         result.PublishedCount.Should().Be(1);
         _fake.PublishCalls.Should().ContainSingle();
         _fake.PublishCalls[0].Should().HaveCount(1);
@@ -367,6 +384,33 @@ public class WebResourceSyncServiceTests : IDisposable
 
         await act.Should().ThrowAsync<PPDS.Cli.Infrastructure.Errors.PpdsException>()
             .Where(ex => ex.ErrorCode == PPDS.Cli.Infrastructure.Errors.ErrorCodes.Validation.FileNotFound);
+    }
+
+    /// <summary>R2: PullAsync threads CancellationToken through the call chain — pre-cancelled token aborts.</summary>
+    [Fact]
+    public async Task PullAsyncRespectsCancellationToken()
+    {
+        _fake.AddText("new_/scripts/app.js", "x");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await _service.PullAsync(PullOpts(), null, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    /// <summary>R2: PushAsync threads CancellationToken through the call chain — pre-cancelled token aborts.</summary>
+    [Fact]
+    public async Task PushAsyncRespectsCancellationToken()
+    {
+        _fake.AddText("new_/scripts/app.js", "v1");
+        await _service.PullAsync(PullOpts(), null);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await _service.PushAsync(PushOpts(), null, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }
 
@@ -446,6 +490,7 @@ internal sealed class FakeWebResourceService : IWebResourceService
 
     public Task<ListResult<WebResourceInfo>> ListAsync(Guid? solutionId = null, bool textOnly = false, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var items = _byName.Values
             .Select(s => new WebResourceInfo(s.Id, s.Name, null, s.Type, false, null, DateTime.UtcNow, null, s.ModifiedOn))
             .Where(i => !textOnly || i.IsTextType)

--- a/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceSyncServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceSyncServiceTests.cs
@@ -1,0 +1,525 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using PPDS.Cli.Services.WebResources;
+using PPDS.Dataverse.Models;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.WebResources;
+
+public class WebResourceSyncServiceTests : IDisposable
+{
+    private readonly string _folder;
+    private readonly FakeWebResourceService _fake;
+    private readonly WebResourceSyncService _service;
+
+    public WebResourceSyncServiceTests()
+    {
+        _folder = Path.Combine(Path.GetTempPath(), "ppds-sync-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_folder);
+        _fake = new FakeWebResourceService();
+        _service = new WebResourceSyncService(_fake, NullLogger<WebResourceSyncService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_folder, recursive: true); } catch { /* best effort */ }
+    }
+
+    private PullOptions PullOpts(
+        bool stripPrefix = false,
+        bool force = false,
+        int[]? typeCodes = null,
+        string? namePattern = null,
+        Guid? solutionId = null,
+        string? solutionName = null,
+        string envUrl = "https://org.crm.dynamics.com")
+        => new(_folder, envUrl, solutionId, solutionName, typeCodes, namePattern, stripPrefix, force);
+
+    private PushOptions PushOpts(
+        bool force = false,
+        bool dryRun = false,
+        bool publish = false,
+        string envUrl = "https://org.crm.dynamics.com")
+        => new(_folder, envUrl, force, dryRun, publish);
+
+    /// <summary>AC-WR-34: pull writes files preserving hierarchical path structure.</summary>
+    [Fact]
+    public async Task PullCreatesDirectoryStructure()
+    {
+        _fake.AddText("new_/scripts/app.js", "alert(1);");
+        _fake.AddText("new_/styles/site.css", "body { color: red; }");
+
+        var result = await _service.PullAsync(PullOpts(), null);
+
+        result.Pulled.Should().HaveCount(2);
+        File.Exists(Path.Combine(_folder, "new_", "scripts", "app.js")).Should().BeTrue();
+        File.Exists(Path.Combine(_folder, "new_", "styles", "site.css")).Should().BeTrue();
+        result.TotalServerCount.Should().Be(2);
+    }
+
+    /// <summary>AC-WR-35: tracking file is written with version, environmentUrl, solution, resources.</summary>
+    [Fact]
+    public async Task PullCreatesTrackingFile()
+    {
+        _fake.AddText("new_/scripts/app.js", "x");
+
+        await _service.PullAsync(PullOpts(solutionName: "core"), null);
+
+        var tracking = await WebResourceTrackingFile.ReadAsync(_folder);
+        tracking.Should().NotBeNull();
+        tracking!.Version.Should().Be(1);
+        tracking.EnvironmentUrl.Should().Be("https://org.crm.dynamics.com");
+        tracking.Solution.Should().Be("core");
+        tracking.Resources.Should().ContainKey("new_/scripts/app.js");
+    }
+
+    /// <summary>AC-WR-37: strip-prefix removes publisher prefix from local paths.</summary>
+    [Fact]
+    public async Task StripPrefixRemovesPublisherPrefix()
+    {
+        _fake.AddText("new_/scripts/app.js", "x");
+
+        var result = await _service.PullAsync(PullOpts(stripPrefix: true), null);
+
+        result.Pulled.Should().ContainSingle();
+        result.Pulled[0].LocalPath.Should().Be(Path.Combine("scripts", "app.js"));
+        File.Exists(Path.Combine(_folder, "scripts", "app.js")).Should().BeTrue();
+        File.Exists(Path.Combine(_folder, "new_", "scripts", "app.js")).Should().BeFalse();
+    }
+
+    /// <summary>AC-WR-38: parallel downloads — multiple GetContentAsync calls observed concurrently.</summary>
+    [Fact]
+    public async Task PullDownloadsInParallel()
+    {
+        for (int i = 0; i < 6; i++)
+        {
+            _fake.AddText($"new_/file{i}.js", $"// file {i}");
+        }
+        _fake.SimulateContentLatencyMs = 80;
+        _fake.TrackConcurrency = true;
+
+        await _service.PullAsync(PullOpts(), null);
+
+        _fake.PeakConcurrency.Should().BeGreaterThan(1);
+        _fake.GetContentCallCount.Should().Be(6);
+    }
+
+    /// <summary>AC-WR-39: pull without --force skips files with local hash drift.</summary>
+    [Fact]
+    public async Task PullSkipsLocallyModifiedFiles()
+    {
+        _fake.AddText("new_/scripts/app.js", "alert('original');");
+        await _service.PullAsync(PullOpts(), null);
+
+        var localFile = Path.Combine(_folder, "new_", "scripts", "app.js");
+        await File.WriteAllTextAsync(localFile, "alert('modified locally');");
+        // Update server with new content (would otherwise overwrite)
+        _fake.UpdateText("new_/scripts/app.js", "alert('updated on server');");
+
+        var result = await _service.PullAsync(PullOpts(), null);
+
+        result.Skipped.Should().ContainSingle(s => s.Name == "new_/scripts/app.js" && s.Reason == "locally modified");
+        (await File.ReadAllTextAsync(localFile)).Should().Be("alert('modified locally');");
+    }
+
+    /// <summary>AC-WR-40: --force overwrites locally modified files.</summary>
+    [Fact]
+    public async Task PullForceOverwritesModifiedFiles()
+    {
+        _fake.AddText("new_/scripts/app.js", "original");
+        await _service.PullAsync(PullOpts(), null);
+
+        var localFile = Path.Combine(_folder, "new_", "scripts", "app.js");
+        await File.WriteAllTextAsync(localFile, "modified locally");
+        _fake.UpdateText("new_/scripts/app.js", "server-side update");
+
+        var result = await _service.PullAsync(PullOpts(force: true), null);
+
+        result.Pulled.Should().ContainSingle(p => p.Name == "new_/scripts/app.js");
+        (await File.ReadAllTextAsync(localFile)).Should().Be("server-side update");
+    }
+
+    /// <summary>AC-WR-41: type-code and name-pattern filters apply in the service (Constitution A1).</summary>
+    [Fact]
+    public async Task PullFiltersResources()
+    {
+        _fake.AddText("new_/scripts/app.js", "x");      // type 3
+        _fake.AddText("new_/scripts/util.js", "x");     // type 3
+        _fake.AddText("new_/styles/site.css", "x", type: 2);
+
+        // Type filter only (only JS)
+        var jsResult = await _service.PullAsync(PullOpts(typeCodes: [3]), null);
+        jsResult.Pulled.Should().HaveCount(2);
+
+        // Reset state
+        Directory.Delete(_folder, recursive: true);
+        Directory.CreateDirectory(_folder);
+
+        // Name pattern only
+        var nameResult = await _service.PullAsync(PullOpts(namePattern: "util"), null);
+        nameResult.Pulled.Should().ContainSingle(p => p.Name == "new_/scripts/util.js");
+    }
+
+    /// <summary>AC-WR-51: resources whose computed path escapes the workspace are rejected.</summary>
+    [Fact]
+    public async Task PullRejectsPathTraversal()
+    {
+        _fake.AddText("../../etc/passwd", "x");
+
+        var result = await _service.PullAsync(PullOpts(), null);
+
+        result.Errors.Should().ContainSingle(e => e.Name == "../../etc/passwd");
+        result.Errors[0].Error.Should().Be("Validation.PathOutsideWorkspace");
+    }
+
+    /// <summary>AC-WR-55: tracking-file merge retains skipped entries and prunes resources removed from server.</summary>
+    [Fact]
+    public async Task PullMergesTrackingFile()
+    {
+        _fake.AddText("new_/a.js", "a-original");
+        _fake.AddText("new_/b.js", "b-original");
+        _fake.AddText("new_/c.js", "c-original");
+        await _service.PullAsync(PullOpts(), null);
+
+        // Modify a.js locally so it gets skipped on next pull; remove c from the server
+        await File.WriteAllTextAsync(Path.Combine(_folder, "new_", "a.js"), "a-modified-locally");
+        _fake.UpdateText("new_/a.js", "a-server-update");
+        _fake.Remove("new_/c.js");
+
+        var result = await _service.PullAsync(PullOpts(), null);
+        var tracking = await WebResourceTrackingFile.ReadAsync(_folder);
+
+        tracking.Should().NotBeNull();
+        // a.js: skipped, retains its prior tracking entry
+        tracking!.Resources.Should().ContainKey("new_/a.js");
+        // b.js: still on server, refreshed
+        tracking.Resources.Should().ContainKey("new_/b.js");
+        // c.js: pruned (no longer on server)
+        tracking.Resources.Should().NotContainKey("new_/c.js");
+        result.Skipped.Should().Contain(s => s.Name == "new_/a.js");
+    }
+
+    /// <summary>AC-WR-50: round-trip pull → edit → push leaves tracking entry consistent.</summary>
+    [Fact]
+    public async Task RoundTripPullEditPush()
+    {
+        _fake.AddText("new_/scripts/app.js", "alert('v1');");
+        await _service.PullAsync(PullOpts(), null);
+
+        var localFile = Path.Combine(_folder, "new_", "scripts", "app.js");
+        await File.WriteAllTextAsync(localFile, "alert('v2');");
+
+        var pushResult = await _service.PushAsync(PushOpts(), null);
+
+        pushResult.Pushed.Should().ContainSingle(p => p.Name == "new_/scripts/app.js");
+        pushResult.Conflicts.Should().BeEmpty();
+        _fake.GetContent("new_/scripts/app.js").Should().Be("alert('v2');");
+    }
+
+    /// <summary>AC-WR-43: push skips files whose hash matches the tracked baseline.</summary>
+    [Fact]
+    public async Task PushSkipsUnchangedFiles()
+    {
+        _fake.AddText("new_/scripts/app.js", "x");
+        await _service.PullAsync(PullOpts(), null);
+        // No local edits
+
+        var result = await _service.PushAsync(PushOpts(), null);
+
+        result.Pushed.Should().BeEmpty();
+        result.Skipped.Should().ContainSingle(s => s.Name == "new_/scripts/app.js" && s.Reason == "unchanged");
+        _fake.UpdateContentCallCount.Should().Be(0);
+    }
+
+    /// <summary>AC-WR-44: server-side change detected as conflict; no upload occurs.</summary>
+    [Fact]
+    public async Task PushDetectsServerConflict()
+    {
+        _fake.AddText("new_/scripts/app.js", "v1");
+        await _service.PullAsync(PullOpts(), null);
+        await File.WriteAllTextAsync(Path.Combine(_folder, "new_", "scripts", "app.js"), "v2-local");
+        // Bump server modifiedOn behind our back
+        _fake.BumpModifiedOn("new_/scripts/app.js");
+
+        var result = await _service.PushAsync(PushOpts(), null);
+
+        result.Conflicts.Should().ContainSingle(c => c.Name == "new_/scripts/app.js");
+        result.Pushed.Should().BeEmpty();
+        _fake.UpdateContentCallCount.Should().Be(0);
+    }
+
+    /// <summary>AC-WR-45: --force bypasses conflict detection and uploads anyway.</summary>
+    [Fact]
+    public async Task PushForceSkipsConflictCheck()
+    {
+        _fake.AddText("new_/scripts/app.js", "v1");
+        await _service.PullAsync(PullOpts(), null);
+        await File.WriteAllTextAsync(Path.Combine(_folder, "new_", "scripts", "app.js"), "v2-local");
+        _fake.BumpModifiedOn("new_/scripts/app.js");
+
+        var result = await _service.PushAsync(PushOpts(force: true), null);
+
+        result.Conflicts.Should().BeEmpty();
+        result.Pushed.Should().ContainSingle();
+        _fake.UpdateContentCallCount.Should().Be(1);
+    }
+
+    /// <summary>AC-WR-46: --dry-run reports planned uploads without mutation.</summary>
+    [Fact]
+    public async Task PushDryRunNoMutation()
+    {
+        _fake.AddText("new_/scripts/app.js", "v1");
+        await _service.PullAsync(PullOpts(), null);
+        await File.WriteAllTextAsync(Path.Combine(_folder, "new_", "scripts", "app.js"), "v2-local");
+
+        var result = await _service.PushAsync(PushOpts(dryRun: true), null);
+
+        result.DryRun.Should().BeTrue();
+        result.Pushed.Should().ContainSingle(p => p.Name == "new_/scripts/app.js");
+        _fake.UpdateContentCallCount.Should().Be(0);
+        _fake.GetContent("new_/scripts/app.js").Should().Be("v1");
+    }
+
+    /// <summary>AC-WR-47: --publish only publishes successfully uploaded resources.</summary>
+    [Fact]
+    public async Task PushWithPublishCallsPublishAsync()
+    {
+        _fake.AddText("new_/a.js", "v1");
+        _fake.AddText("new_/b.js", "v1");
+        await _service.PullAsync(PullOpts(), null);
+        await File.WriteAllTextAsync(Path.Combine(_folder, "new_", "a.js"), "v2");
+        // b.js unchanged → should not be in publish set
+
+        var result = await _service.PushAsync(PushOpts(publish: true), null);
+
+        result.PublishedCount.Should().Be(1);
+        _fake.PublishCalls.Should().ContainSingle();
+        _fake.PublishCalls[0].Should().HaveCount(1);
+        _fake.PublishCalls[0][0].Should().Be(_fake.IdOf("new_/a.js"));
+    }
+
+    /// <summary>AC-WR-48: tracking file is updated with new modifiedOn and hash after upload.</summary>
+    [Fact]
+    public async Task PushUpdatesTrackingFile()
+    {
+        _fake.AddText("new_/scripts/app.js", "v1");
+        await _service.PullAsync(PullOpts(), null);
+
+        var trackingBefore = await WebResourceTrackingFile.ReadAsync(_folder);
+        var hashBefore = trackingBefore!.Resources["new_/scripts/app.js"].Hash;
+
+        await File.WriteAllTextAsync(Path.Combine(_folder, "new_", "scripts", "app.js"), "v2-changed");
+        _fake.SetNextWriteModifiedOn("new_/scripts/app.js", new DateTime(2030, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+
+        await _service.PushAsync(PushOpts(), null);
+
+        var trackingAfter = await WebResourceTrackingFile.ReadAsync(_folder);
+        var entry = trackingAfter!.Resources["new_/scripts/app.js"];
+        entry.Hash.Should().NotBe(hashBefore);
+        entry.ModifiedOn.Should().Be(new DateTime(2030, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+    }
+
+    /// <summary>AC-WR-53: push skips binary types (read-only) with warning reason.</summary>
+    [Fact]
+    public async Task PushSkipsBinaryTypes()
+    {
+        _fake.AddBinary("new_/images/logo.png", type: 5);
+        await _service.PullAsync(PullOpts(), null);
+
+        var result = await _service.PushAsync(PushOpts(), null);
+
+        result.Skipped.Should().ContainSingle(s => s.Name == "new_/images/logo.png" && s.Reason == "binary type (read-only)");
+        _fake.UpdateContentCallCount.Should().Be(0);
+    }
+
+    /// <summary>AC-WR-54: tracked files missing from disk are warned and skipped, not deleted.</summary>
+    [Fact]
+    public async Task PushSkipsDeletedFiles()
+    {
+        _fake.AddText("new_/scripts/app.js", "v1");
+        await _service.PullAsync(PullOpts(), null);
+
+        File.Delete(Path.Combine(_folder, "new_", "scripts", "app.js"));
+
+        var result = await _service.PushAsync(PushOpts(), null);
+
+        result.Skipped.Should().ContainSingle(s => s.Name == "new_/scripts/app.js" && s.Reason == "file deleted");
+        _fake.UpdateContentCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PushErrorsOnEnvironmentMismatch_WhenNotForced()
+    {
+        _fake.AddText("new_/scripts/app.js", "v1");
+        await _service.PullAsync(PullOpts(envUrl: "https://org-A.crm.dynamics.com"), null);
+
+        var act = async () => await _service.PushAsync(PushOpts(envUrl: "https://org-B.crm.dynamics.com"), null);
+
+        await act.Should().ThrowAsync<PPDS.Cli.Infrastructure.Errors.PpdsException>()
+            .Where(ex => ex.ErrorCode == PPDS.Cli.Infrastructure.Errors.ErrorCodes.Connection.InvalidEnvironmentUrl);
+    }
+
+    [Fact]
+    public async Task PushErrorsOnMissingTrackingFile()
+    {
+        // No pull performed → no tracking file
+        var act = async () => await _service.PushAsync(PushOpts(), null);
+
+        await act.Should().ThrowAsync<PPDS.Cli.Infrastructure.Errors.PpdsException>()
+            .Where(ex => ex.ErrorCode == PPDS.Cli.Infrastructure.Errors.ErrorCodes.Validation.FileNotFound);
+    }
+}
+
+/// <summary>
+/// Test double for IWebResourceService that holds an in-memory map of resources.
+/// </summary>
+internal sealed class FakeWebResourceService : IWebResourceService
+{
+    private readonly Dictionary<string, ResourceState> _byName = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<Guid, string> _idToName = [];
+    private int _currentParallel;
+    private int _peak;
+    private readonly Dictionary<string, DateTime> _nextWriteModifiedOn = new(StringComparer.OrdinalIgnoreCase);
+
+    public int GetContentCallCount;
+    public int UpdateContentCallCount;
+    public int PeakConcurrency => _peak;
+    public bool TrackConcurrency;
+    public int SimulateContentLatencyMs;
+    public List<IReadOnlyList<Guid>> PublishCalls { get; } = new();
+
+    public void AddText(string name, string content, int type = 3)
+    {
+        var id = Guid.NewGuid();
+        _byName[name] = new ResourceState
+        {
+            Id = id,
+            Name = name,
+            Type = type,
+            Content = content,
+            ModifiedOn = DateTime.UtcNow,
+        };
+        _idToName[id] = name;
+    }
+
+    public void AddBinary(string name, int type)
+    {
+        var id = Guid.NewGuid();
+        _byName[name] = new ResourceState
+        {
+            Id = id,
+            Name = name,
+            Type = type,
+            Content = null,
+            ModifiedOn = DateTime.UtcNow,
+        };
+        _idToName[id] = name;
+    }
+
+    public void UpdateText(string name, string content)
+    {
+        _byName[name].Content = content;
+        _byName[name].ModifiedOn = DateTime.UtcNow.AddSeconds(1);
+    }
+
+    public void Remove(string name)
+    {
+        if (_byName.Remove(name, out var state))
+        {
+            _idToName.Remove(state.Id);
+        }
+    }
+
+    public void BumpModifiedOn(string name)
+    {
+        _byName[name].ModifiedOn = DateTime.UtcNow.AddMinutes(5);
+    }
+
+    public void SetNextWriteModifiedOn(string name, DateTime modifiedOn)
+    {
+        _nextWriteModifiedOn[name] = modifiedOn;
+    }
+
+    public Guid IdOf(string name) => _byName[name].Id;
+
+    public string? GetContent(string name) => _byName.TryGetValue(name, out var s) ? s.Content : null;
+
+    public Task<ListResult<WebResourceInfo>> ListAsync(Guid? solutionId = null, bool textOnly = false, CancellationToken cancellationToken = default)
+    {
+        var items = _byName.Values
+            .Select(s => new WebResourceInfo(s.Id, s.Name, null, s.Type, false, null, DateTime.UtcNow, null, s.ModifiedOn))
+            .Where(i => !textOnly || i.IsTextType)
+            .ToList();
+        return Task.FromResult(new ListResult<WebResourceInfo>
+        {
+            Items = items,
+            TotalCount = items.Count,
+            FiltersApplied = [],
+        });
+    }
+
+    public Task<WebResourceInfo?> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (!_idToName.TryGetValue(id, out var name)) return Task.FromResult<WebResourceInfo?>(null);
+        var s = _byName[name];
+        return Task.FromResult<WebResourceInfo?>(new WebResourceInfo(s.Id, s.Name, null, s.Type, false, null, DateTime.UtcNow, null, s.ModifiedOn));
+    }
+
+    public async Task<WebResourceContent?> GetContentAsync(Guid id, bool published = false, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref GetContentCallCount);
+        if (TrackConcurrency)
+        {
+            var current = Interlocked.Increment(ref _currentParallel);
+            int oldPeak;
+            do { oldPeak = _peak; } while (current > oldPeak && Interlocked.CompareExchange(ref _peak, current, oldPeak) != oldPeak);
+        }
+        try
+        {
+            if (SimulateContentLatencyMs > 0)
+            {
+                await Task.Delay(SimulateContentLatencyMs, cancellationToken);
+            }
+            if (!_idToName.TryGetValue(id, out var name)) return null;
+            var s = _byName[name];
+            return new WebResourceContent(s.Id, s.Name, s.Type, s.Content, s.ModifiedOn);
+        }
+        finally
+        {
+            if (TrackConcurrency) Interlocked.Decrement(ref _currentParallel);
+        }
+    }
+
+    public Task<DateTime?> GetModifiedOnAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (!_idToName.TryGetValue(id, out var name)) return Task.FromResult<DateTime?>(null);
+        return Task.FromResult<DateTime?>(_byName[name].ModifiedOn);
+    }
+
+    public Task UpdateContentAsync(Guid id, string content, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref UpdateContentCallCount);
+        if (!_idToName.TryGetValue(id, out var name)) throw new KeyNotFoundException(id.ToString());
+        var s = _byName[name];
+        s.Content = content;
+        s.ModifiedOn = _nextWriteModifiedOn.TryGetValue(name, out var stamp) ? stamp : DateTime.UtcNow;
+        return Task.CompletedTask;
+    }
+
+    public Task<int> PublishAsync(IReadOnlyList<Guid> ids, CancellationToken cancellationToken = default)
+    {
+        PublishCalls.Add(ids.ToList());
+        return Task.FromResult(ids.Count);
+    }
+
+    public Task PublishAllAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    private sealed class ResourceState
+    {
+        public Guid Id { get; set; }
+        public required string Name { get; set; }
+        public int Type { get; set; }
+        public string? Content { get; set; }
+        public DateTime ModifiedOn { get; set; }
+    }
+}

--- a/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceSyncServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceSyncServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Services.WebResources;
 using PPDS.Dataverse.Models;
 using Xunit;
@@ -104,11 +105,17 @@ public class WebResourceSyncServiceTests : IDisposable
         }
         _fake.SimulateContentLatencyMs = 80;
         _fake.TrackConcurrency = true;
+        var progress = new RecordingOperationProgress();
 
-        await _service.PullAsync(PullOpts(), null);
+        await _service.PullAsync(PullOpts(), progress);
 
         _fake.PeakConcurrency.Should().BeGreaterThan(1);
         _fake.GetContentCallCount.Should().Be(6);
+        // Progress reporting (AC-WR-38): one ReportProgress call per resource,
+        // current values cover 1..6, total is 6 for every call.
+        progress.ProgressCalls.Should().HaveCount(6);
+        progress.ProgressCalls.Select(c => c.Current).OrderBy(c => c).Should().Equal(1, 2, 3, 4, 5, 6);
+        progress.ProgressCalls.Should().OnlyContain(c => c.Total == 6);
     }
 
     /// <summary>AC-WR-39: pull without --force skips files with local hash drift.</summary>
@@ -182,7 +189,23 @@ public class WebResourceSyncServiceTests : IDisposable
         var result = await _service.PullAsync(PullOpts(), null);
 
         result.Errors.Should().ContainSingle(e => e.Name == "../../etc/passwd");
-        result.Errors[0].Error.Should().Be("Validation.PathOutsideWorkspace");
+        result.Errors[0].Error.Should().Be("name resolves outside target folder");
+    }
+
+    /// <summary>AC-WR-37 follow-up: --strip-prefix collisions across publishers do not silently overwrite — second-and-later claimants are reported as errors.</summary>
+    [Fact]
+    public async Task PullRejectsStripPrefixCollisions()
+    {
+        _fake.AddText("new_/scripts/app.js", "from-new");
+        _fake.AddText("dev_/scripts/app.js", "from-dev");
+
+        var result = await _service.PullAsync(PullOpts(stripPrefix: true), null);
+
+        // First wins, second errors. We don't assert which is "first" because
+        // it depends on enumeration order, but exactly one must succeed and one error.
+        result.Pulled.Should().HaveCount(1);
+        result.Errors.Should().HaveCount(1);
+        result.Errors[0].Error.Should().Contain("collides with");
     }
 
     /// <summary>AC-WR-55: tracking-file merge retains skipped entries and prunes resources removed from server.</summary>
@@ -567,4 +590,25 @@ internal sealed class FakeWebResourceService : IWebResourceService
         public string? Content { get; set; }
         public DateTime ModifiedOn { get; set; }
     }
+}
+
+internal sealed class RecordingOperationProgress : IOperationProgress
+{
+    public List<string> StatusMessages { get; } = new();
+    public List<(int Current, int Total, string? Message)> ProgressCalls { get; } = new();
+    private readonly object _lock = new();
+
+    public void ReportStatus(string message)
+    {
+        lock (_lock) { StatusMessages.Add(message); }
+    }
+
+    public void ReportProgress(int current, int total, string? message = null)
+    {
+        lock (_lock) { ProgressCalls.Add((current, total, message)); }
+    }
+
+    public void ReportProgress(double fraction, string? message = null) { }
+    public void ReportComplete(string message) { }
+    public void ReportError(string message) { }
 }

--- a/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceTrackingFileTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceTrackingFileTests.cs
@@ -95,17 +95,19 @@ public class WebResourceTrackingFileTests : IDisposable
         hash.Should().StartWith("sha256:");
         hash.Length.Should().Be("sha256:".Length + 64);
 
+        var modifiedOn = new DateTime(2026, 4, 20, 14, 22, 0, DateTimeKind.Utc);
+        var pulledAt = new DateTime(2026, 4, 25, 10, 30, 0, DateTimeKind.Utc);
         var trackingFile = new WebResourceTrackingFile(
             Version: 1,
             EnvironmentUrl: "https://x",
             Solution: null,
             StripPrefix: false,
-            PulledAt: DateTime.UtcNow,
+            PulledAt: pulledAt,
             Resources: new Dictionary<string, TrackedResource>
             {
                 ["new_/sample.js"] = new TrackedResource(
                     Id: Guid.NewGuid(),
-                    ModifiedOn: DateTime.UtcNow,
+                    ModifiedOn: modifiedOn,
                     Hash: hash,
                     LocalPath: "sample.js",
                     WebResourceType: 3),
@@ -114,7 +116,7 @@ public class WebResourceTrackingFileTests : IDisposable
         await WebResourceTrackingFile.WriteAsync(_folder, trackingFile);
         var roundTripped = await WebResourceTrackingFile.ReadAsync(_folder);
         roundTripped!.Resources["new_/sample.js"].Hash.Should().Be(hash);
-        roundTripped.Resources["new_/sample.js"].ModifiedOn.Should().BeCloseTo(trackingFile.PulledAt, TimeSpan.FromSeconds(1));
+        roundTripped.Resources["new_/sample.js"].ModifiedOn.Should().Be(modifiedOn);
     }
 
     [Fact]

--- a/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceTrackingFileTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebResources/WebResourceTrackingFileTests.cs
@@ -1,0 +1,165 @@
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using PPDS.Cli.Services.WebResources;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.WebResources;
+
+public class WebResourceTrackingFileTests : IDisposable
+{
+    private readonly string _folder;
+
+    public WebResourceTrackingFileTests()
+    {
+        _folder = Path.Combine(Path.GetTempPath(), "ppds-trackingfile-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_folder);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_folder, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task WriteThenRead_RoundTripsAllFields()
+    {
+        var trackingFile = new WebResourceTrackingFile(
+            Version: 1,
+            EnvironmentUrl: "https://org.crm.dynamics.com",
+            Solution: "core_solution",
+            StripPrefix: true,
+            PulledAt: new DateTime(2026, 4, 25, 10, 30, 0, DateTimeKind.Utc),
+            Resources: new Dictionary<string, TrackedResource>
+            {
+                ["new_/scripts/app.js"] = new TrackedResource(
+                    Id: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                    ModifiedOn: new DateTime(2026, 4, 20, 14, 22, 0, DateTimeKind.Utc),
+                    Hash: "sha256:abc123",
+                    LocalPath: "scripts/app.js",
+                    WebResourceType: 3),
+            });
+
+        await WebResourceTrackingFile.WriteAsync(_folder, trackingFile);
+
+        var roundTripped = await WebResourceTrackingFile.ReadAsync(_folder);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.Version.Should().Be(1);
+        roundTripped.EnvironmentUrl.Should().Be("https://org.crm.dynamics.com");
+        roundTripped.Solution.Should().Be("core_solution");
+        roundTripped.StripPrefix.Should().BeTrue();
+        roundTripped.PulledAt.Should().Be(new DateTime(2026, 4, 25, 10, 30, 0, DateTimeKind.Utc));
+        roundTripped.Resources.Should().ContainKey("new_/scripts/app.js");
+        var resource = roundTripped.Resources["new_/scripts/app.js"];
+        resource.Id.Should().Be(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        resource.ModifiedOn.Should().Be(new DateTime(2026, 4, 20, 14, 22, 0, DateTimeKind.Utc));
+        resource.Hash.Should().Be("sha256:abc123");
+        resource.LocalPath.Should().Be("scripts/app.js");
+        resource.WebResourceType.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReturnsNull_WhenFileMissing()
+    {
+        var result = await WebResourceTrackingFile.ReadAsync(_folder);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WriteAsync_CreatesPpdsSubdirectory()
+    {
+        var tracking = new WebResourceTrackingFile(
+            Version: 1,
+            EnvironmentUrl: "https://x",
+            Solution: null,
+            StripPrefix: false,
+            PulledAt: DateTime.UtcNow,
+            Resources: new Dictionary<string, TrackedResource>());
+
+        await WebResourceTrackingFile.WriteAsync(_folder, tracking);
+
+        File.Exists(Path.Combine(_folder, ".ppds", "webresources.json")).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// AC-WR-36: tracking file records SHA256 hash. Verify hash format and content match.
+    /// </summary>
+    [Fact]
+    public async Task TrackingFileContainsHashAndTimestamp()
+    {
+        var sourcePath = Path.Combine(_folder, "sample.js");
+        await File.WriteAllTextAsync(sourcePath, "alert('hello');");
+        var hash = await WebResourceTrackingFile.ComputeHashAsync(sourcePath);
+
+        hash.Should().StartWith("sha256:");
+        hash.Length.Should().Be("sha256:".Length + 64);
+
+        var trackingFile = new WebResourceTrackingFile(
+            Version: 1,
+            EnvironmentUrl: "https://x",
+            Solution: null,
+            StripPrefix: false,
+            PulledAt: DateTime.UtcNow,
+            Resources: new Dictionary<string, TrackedResource>
+            {
+                ["new_/sample.js"] = new TrackedResource(
+                    Id: Guid.NewGuid(),
+                    ModifiedOn: DateTime.UtcNow,
+                    Hash: hash,
+                    LocalPath: "sample.js",
+                    WebResourceType: 3),
+            });
+
+        await WebResourceTrackingFile.WriteAsync(_folder, trackingFile);
+        var roundTripped = await WebResourceTrackingFile.ReadAsync(_folder);
+        roundTripped!.Resources["new_/sample.js"].Hash.Should().Be(hash);
+        roundTripped.Resources["new_/sample.js"].ModifiedOn.Should().BeCloseTo(trackingFile.PulledAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task ComputeHashAsync_MatchesKnownSha256()
+    {
+        var path = Path.Combine(_folder, "known.txt");
+        var content = "abc";
+        await File.WriteAllBytesAsync(path, Encoding.UTF8.GetBytes(content));
+
+        var hash = await WebResourceTrackingFile.ComputeHashAsync(path);
+
+        // Known SHA256 of "abc" (raw bytes)
+        var expected = "sha256:" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content))).ToLowerInvariant();
+        hash.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ComputeHashAsync_NegativeCase_DifferentContentProducesDifferentHash()
+    {
+        var path1 = Path.Combine(_folder, "a.txt");
+        var path2 = Path.Combine(_folder, "b.txt");
+        await File.WriteAllTextAsync(path1, "alert('a');");
+        await File.WriteAllTextAsync(path2, "alert('b');");
+
+        var hash1 = await WebResourceTrackingFile.ComputeHashAsync(path1);
+        var hash2 = await WebResourceTrackingFile.ComputeHashAsync(path2);
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    [Fact]
+    public async Task WriteAsync_RespectsCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var tracking = new WebResourceTrackingFile(
+            Version: 1,
+            EnvironmentUrl: "https://x",
+            Solution: null,
+            StripPrefix: false,
+            PulledAt: DateTime.UtcNow,
+            Resources: new Dictionary<string, TrackedResource>());
+
+        var act = async () => await WebResourceTrackingFile.WriteAsync(_folder, tracking, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ppds webresources pull <folder>` and `ppds webresources push <folder>` for round-trip web-resource editing with `.ppds/webresources.json` tracking.
- Pull supports `--solution`, `--type`, `--name`, `--strip-prefix`, `--force`; push supports `--force`, `--dry-run`, `--publish` with SHA-256 hash + `modifiedOn` conflict detection (exit 10 = `PreconditionFailed` on server-side drift).
- All business logic lives in `IWebResourceSyncService` (Constitution A1); commands are thin wrappers. Pull rejects path-traversal names and strip-prefix path collisions instead of silently overwriting.

[size-waived: cohesive feature spanning spec + tracking model + sync service + two CLI commands + tests for issues #161/#162; splitting would create non-functional intermediate PRs since the commands depend on the sync service which depends on the tracking model]

Closes #161
Closes #162

## Test Plan
- [x] `dotnet test PPDS.sln --filter "Category!=Integration"` — 3550 PPDS.Cli tests pass across net8/9/10
- [x] AC-WR-34 through AC-WR-55 all green; spec rows reference real test methods
- [x] Round-trip pull → edit → push --dry-run against live `PPDS Demo - Dev` env (1 of 20686 resources, `--name ppds_`)
- [x] Push with stale tracking exits 10 and prints tracked-vs-server timestamps
- [x] Push with missing tracking errors with `Run 'ppds webresources pull <folder>' first`
- [x] Strip-prefix collision regression test (`PullRejectsStripPrefixCollisions`) added

## Verification
- [x] /gates passed
- [x] /verify cli completed (round-trip + edge cases on live env)
- [x] /qa cli completed (10 findings, 6 fixed)
- [x] /review completed (26 findings, addressed in converge round 1)
- [x] Pre-PR self-review (round 2) found 4 DEFECTs — all fixed in commit 9d9f36f01

🤖 Generated with [Claude Code](https://claude.com/claude-code)