### PR TITLE
fix(docs-gen): escape curly braces in MdxEscape for MDX compatibility

### DIFF
--- a/scripts/docs-gen/PPDS.DocsGen.Common/MdxEscape.cs
+++ b/scripts/docs-gen/PPDS.DocsGen.Common/MdxEscape.cs
@@ -6,9 +6,10 @@ namespace PPDS.DocsGen.Common;
 /// Shared utility used by all docs-gen generators to produce MDX-safe markdown.
 /// </summary>
 /// <remarks>
-/// MDX parses angle brackets as JSX. Any <c>&lt;</c> or <c>&gt;</c> in prose
-/// that is not already inside a fenced code block or inline-code span must be
-/// HTML-entity-encoded or strict-MDX will reject the document (see AC-23).
+/// MDX parses angle brackets as JSX and curly braces as expressions. Any
+/// <c>&lt;</c>, <c>&gt;</c>, <c>{</c>, or <c>}</c> in prose that is not
+/// already inside a fenced code block or inline-code span must be escaped or
+/// strict-MDX will reject the document (see AC-23).
 /// </remarks>
 public static class MdxEscape
 {
@@ -104,6 +105,12 @@ public static class MdxEscape
                 case '>':
                     sb.Append("&gt;");
                     break;
+                case '{':
+                    sb.Append("\\{");
+                    break;
+                case '}':
+                    sb.Append("\\}");
+                    break;
                 default:
                     sb.Append(c);
                     break;
@@ -132,7 +139,9 @@ public static class MdxEscape
         return raw
             .Replace("&", "&amp;")
             .Replace("<", "&lt;")
-            .Replace(">", "&gt;");
+            .Replace(">", "&gt;")
+            .Replace("{", "\\{")
+            .Replace("}", "\\}");
     }
 
     /// <summary>

--- a/scripts/docs-gen/PPDS.DocsGen.Common/MdxEscape.cs
+++ b/scripts/docs-gen/PPDS.DocsGen.Common/MdxEscape.cs
@@ -130,18 +130,7 @@ public static class MdxEscape
     /// </summary>
     public static string Heading(string raw)
     {
-        if (string.IsNullOrEmpty(raw))
-        {
-            return raw;
-        }
-
-        // Replace & first to avoid double-escaping entities produced below.
-        return raw
-            .Replace("&", "&amp;")
-            .Replace("<", "&lt;")
-            .Replace(">", "&gt;")
-            .Replace("{", "\\{")
-            .Replace("}", "\\}");
+        return Prose(raw);
     }
 
     /// <summary>

--- a/tests/PPDS.DocsGen.Common.Tests/MdxEscapeTests.cs
+++ b/tests/PPDS.DocsGen.Common.Tests/MdxEscapeTests.cs
@@ -131,6 +131,40 @@ public class MdxEscapeTests
     }
 
     [Fact]
+    public void Prose_EscapesCurlyBracesInProse()
+    {
+        var result = MdxEscape.Prose("options: [{\"label\": \"Active\"}]");
+
+        result.Should().Be("options: [\\{\"label\": \"Active\"\\}]");
+    }
+
+    [Fact]
+    public void Prose_PreservesCurlyBracesInFencedCode()
+    {
+        var input = "text\n```json\n{\"key\": \"val\"}\n```\nmore";
+
+        var result = MdxEscape.Prose(input);
+
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void Prose_PreservesCurlyBracesInInlineCode()
+    {
+        var result = MdxEscape.Prose("use `{foo}` here");
+
+        result.Should().Be("use `{foo}` here");
+    }
+
+    [Fact]
+    public void Heading_EscapesCurlyBraces()
+    {
+        var result = MdxEscape.Heading("Dict{K, V}");
+
+        result.Should().Be("Dict\\{K, V\\}");
+    }
+
+    [Fact]
     public void InlineCode_Deterministic()
     {
         // AC-19 determinism: same input → byte-identical output on repeat calls.


### PR DESCRIPTION
## Summary
- MDX interprets `{...}` as JSX expressions — tool descriptions containing JSON examples (e.g. `{"label": "Active"}`) cause Docusaurus build failures
- Escape `{` → `\{` and `}` → `\}` in both `Prose()` and `Heading()` methods
- 4 new tests for curly brace escaping in prose, fenced code, inline code, and headings

## Context
ppds-docs PR #24 (opened by docs-release workflow) failed Docusaurus test-build because `ppds_metadata_create_choice.md` contained unescaped curly braces in the `optionsJson` parameter description.

## Test Plan
- [x] All 20 MdxEscape tests pass (16 existing + 4 new)
- [x] All 14 libs-reflect golden-file tests pass
- [x] All 5 CI workflow regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)