### PR TITLE
feat(pr-monitor): escalate on sustained CI POLL_ERROR

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -284,6 +284,7 @@ def poll_ci(worktree, pr_number, logger):
                        ci_checks_posting=True, after_polls=consecutive_errors)
         consecutive_errors = 0
         first_error_time = None
+        escalated = False
 
         # `gh pr checks` returns `bucket` as the conclusion category:
         #   pass | fail | pending | skipping | cancel

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -41,6 +41,8 @@ from triage_common import (
 
 CI_POLL_INTERVAL = 30       # seconds between CI status checks
 CI_MAX_WAIT = 3600          # 60 minutes max for CI
+CI_ESCALATION_THRESHOLD = 3       # consecutive no-check polls before escalation
+CI_ESCALATION_MIN_ELAPSED = 120   # seconds since first error before escalation
 GEMINI_POLL_INTERVAL = 30   # seconds between Gemini comment polls
 GEMINI_MAX_WAIT = 300       # 5 minutes max for Gemini
 MAX_TRIAGE_ITERATIONS = 3   # max triage -> CI re-check cycles
@@ -198,6 +200,25 @@ def get_repo_slug(worktree):
     return _get_repo_slug(worktree, shakedown=bool(SHAKEDOWN))
 
 
+def _escalate_ci_no_checks(worktree, pr_number, logger, consecutive_errors,
+                           first_error_time):
+    """Fire a notification when CI checks are not being posted."""
+    elapsed = int(time.time() - first_error_time)
+    logger.log("ci", "ESCALATION",
+               consecutive_errors=consecutive_errors,
+               elapsed_since_first=f"{elapsed}s")
+    msg = (
+        f"PR #{pr_number} has had no CI checks reported for "
+        f">{elapsed}s after {consecutive_errors} polls. Investigate: "
+        f"(a) CI workflow posting, (b) branch protection rules, "
+        f"(c) workflow file syntax."
+    )
+    try:
+        run_notify(worktree, pr_number, logger, message=msg)
+    except Exception:  # noqa: BLE001 — fire-and-forget
+        logger.log("ci", "ESCALATION_NOTIFY_ERROR")
+
+
 def poll_ci(worktree, pr_number, logger):
     """Poll CI checks until all pass, any fail, or timeout.
 
@@ -208,6 +229,22 @@ def poll_ci(worktree, pr_number, logger):
         return "pass"
 
     start = time.time()
+    consecutive_errors = 0
+    first_error_time = None
+    escalated = False
+
+    def _track_error():
+        nonlocal consecutive_errors, first_error_time, escalated
+        consecutive_errors += 1
+        if first_error_time is None:
+            first_error_time = time.time()
+        if (not escalated
+                and consecutive_errors >= CI_ESCALATION_THRESHOLD
+                and time.time() - first_error_time >= CI_ESCALATION_MIN_ELAPSED):
+            _escalate_ci_no_checks(worktree, pr_number, logger,
+                                   consecutive_errors, first_error_time)
+            escalated = True
+
     while time.time() - start < CI_MAX_WAIT:
         try:
             result = subprocess.run(
@@ -217,11 +254,13 @@ def poll_ci(worktree, pr_number, logger):
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
             logger.log("ci", "POLL_ERROR", error=str(e))
+            _track_error()
             time.sleep(CI_POLL_INTERVAL)
             continue
 
         if result.returncode != 0:
             logger.log("ci", "POLL_ERROR", stderr=result.stderr.strip()[:200])
+            _track_error()
             time.sleep(CI_POLL_INTERVAL)
             continue
 
@@ -235,8 +274,16 @@ def poll_ci(worktree, pr_number, logger):
         if not checks:
             logger.log("ci", "NO_CHECKS_YET",
                        elapsed=f"{int(time.time() - start)}s")
+            _track_error()
             time.sleep(CI_POLL_INTERVAL)
             continue
+
+        # Checks found — reset error tracking and log recovery if escalated
+        if escalated:
+            logger.log("ci", "RECOVERED",
+                       ci_checks_posting=True, after_polls=consecutive_errors)
+        consecutive_errors = 0
+        first_error_time = None
 
         # `gh pr checks` returns `bucket` as the conclusion category:
         #   pass | fail | pending | skipping | cancel

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1893,3 +1893,99 @@ class TestMsysPathconvNotInherited:
         env = mock_popen.call_args.kwargs.get("env", {})
         assert "MSYS_NO_PATHCONV" not in env, \
             "MSYS_NO_PATHCONV in claude env breaks hook path resolution (#910)"
+
+
+# ---------------------------------------------------------------------------
+# PR #956: CI poll-error escalation
+# ---------------------------------------------------------------------------
+
+
+class TestCiEscalation:
+    """PR #956: escalate when CI checks aren't posted after sustained POLL_ERROR."""
+
+    def test_poll_error_below_threshold_does_not_escalate(self, tmp_path):
+        """Fewer than CI_ESCALATION_THRESHOLD errors: no notification."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+
+        call_count = [0]
+
+        def mock_run(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return subprocess.CompletedProcess(
+                    args=[], returncode=1,
+                    stdout="", stderr="no checks reported")
+            return _gh_checks_json([
+                {"name": "build", "state": "COMPLETED", "bucket": "pass"},
+            ])
+
+        with patch("pr_monitor.subprocess.run", side_effect=mock_run), \
+             patch("pr_monitor.run_notify") as mock_notify, \
+             patch("pr_monitor.CI_POLL_INTERVAL", 0), \
+             patch("pr_monitor.CI_ESCALATION_MIN_ELAPSED", 0):
+            result = pr_monitor.poll_ci(wt, 42, logger)
+
+        assert result == "pass"
+        mock_notify.assert_not_called()
+
+    def test_poll_error_at_threshold_escalates_once(self, tmp_path):
+        """>=CI_ESCALATION_THRESHOLD errors: run_notify fires exactly once."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+
+        call_count = [0]
+
+        def mock_run(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 5:
+                return subprocess.CompletedProcess(
+                    args=[], returncode=1,
+                    stdout="", stderr="no checks reported")
+            return _gh_checks_json([
+                {"name": "build", "state": "COMPLETED", "bucket": "pass"},
+            ])
+
+        with patch("pr_monitor.subprocess.run", side_effect=mock_run), \
+             patch("pr_monitor.run_notify") as mock_notify, \
+             patch("pr_monitor.CI_POLL_INTERVAL", 0), \
+             patch("pr_monitor.CI_ESCALATION_THRESHOLD", 3), \
+             patch("pr_monitor.CI_ESCALATION_MIN_ELAPSED", 0):
+            result = pr_monitor.poll_ci(wt, 42, logger)
+
+        assert result == "pass"
+        mock_notify.assert_called_once()
+        msg = mock_notify.call_args.kwargs.get("message", "")
+        assert "no CI checks reported" in msg
+        assert "42" in msg
+
+    def test_poll_error_recovers_after_escalation_logs_recovery(self, tmp_path):
+        """After escalation, checks posting triggers RECOVERED log entry."""
+        wt = _make_worktree(tmp_path)
+        log_path = str(tmp_path / "test.log")
+        logger = pr_monitor.Logger(log_path)
+
+        call_count = [0]
+
+        def mock_run(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 4:
+                return subprocess.CompletedProcess(
+                    args=[], returncode=1,
+                    stdout="", stderr="no checks reported")
+            return _gh_checks_json([
+                {"name": "build", "state": "COMPLETED", "bucket": "pass"},
+            ])
+
+        with patch("pr_monitor.subprocess.run", side_effect=mock_run), \
+             patch("pr_monitor.run_notify"), \
+             patch("pr_monitor.CI_POLL_INTERVAL", 0), \
+             patch("pr_monitor.CI_ESCALATION_THRESHOLD", 3), \
+             patch("pr_monitor.CI_ESCALATION_MIN_ELAPSED", 0):
+            result = pr_monitor.poll_ci(wt, 42, logger)
+
+        assert result == "pass"
+        with open(log_path) as f:
+            log_contents = f.read()
+        assert "RECOVERED" in log_contents
+        assert "ci_checks_posting=True" in log_contents


### PR DESCRIPTION
## Summary

- After 3 consecutive CI poll errors (POLL_ERROR or NO_CHECKS_YET) spanning >2 minutes, the monitor fires a notification via `run_notify` with a diagnostic message and logs an `ESCALATION` event
- Escalation fires once per episode — flag resets on recovery, allowing re-escalation if checks disappear again
- When checks start posting after an escalation, the monitor logs `RECOVERED ci_checks_posting=True after_polls=N`

Addresses the silent-loop behavior observed in PR #956, where 12+ minutes of `POLL_ERROR stderr=no checks reported` went unescalated because the foreground agent treated the task output as "routine or benign."

## Test Plan

- [x] `test_poll_error_below_threshold_does_not_escalate` — 2 errors then success: no notification
- [x] `test_poll_error_at_threshold_escalates_once` — 5 errors then success: exactly 1 notification with diagnostic message
- [x] `test_poll_error_recovers_after_escalation_logs_recovery` — 4 errors then success: RECOVERED logged
- [x] Full test suite: 78/78 pass, 0 regressions

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: workflow)
- [x] Self-review completed (1 CONCERN fixed, 2 NITs skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)