### PR TITLE
fix(pipeline): auto-commit stranded files on STALL_TIMEOUT + RESUME_HINT

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -29,6 +29,7 @@ Options:
 import argparse
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -336,7 +337,7 @@ def auto_commit_stranded(worktree_path, stage, logger, *,
         return False
     try:
         dirty = subprocess.run(
-            ["git", "status", "--porcelain"],
+            ["git", "status", "--porcelain", "--untracked-files=all"],
             cwd=worktree_path, capture_output=True, text=True,
             encoding="utf-8", errors="replace", timeout=10,
         )
@@ -1695,7 +1696,12 @@ def main():
                 resume_parts.extend(["--spec", source_rel, "--branch", branch])
             resume_parts.extend(["--from", resume_stage,
                                  "--worktree", worktree_path])
-            resume_cmd = " ".join(resume_parts)
+            if args.dry_run:
+                resume_parts.append("--dry-run")
+            if args.max_stage_seconds is not None:
+                resume_parts.extend(["--max-stage-seconds",
+                                     str(args.max_stage_seconds)])
+            resume_cmd = shlex.join(resume_parts)
             log(logger, "pipeline", "RESUME_HINT", command=resume_cmd)
 
             last_output = _read_last_lines(worktree_path, _failed_log_stage, 50)

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -189,6 +189,16 @@ def should_converge(state):
         return True, "review FAIL"
 
 
+def compute_resume_stage(failed_stage):
+    """Map a failed stage name to a valid ``--from`` stage for resume."""
+    if failed_stage in STAGES:
+        return failed_stage
+    if "reconverge" in failed_stage:
+        return "converge"
+    base = failed_stage.split("-")[0]
+    return base if base in STAGES else failed_stage
+
+
 def find_last_completed_stage(log_path):
     """Parse pipeline.log to find the last completed stage for --resume."""
     if not os.path.exists(log_path):
@@ -313,6 +323,47 @@ def classify_activity(current_size, last_size, git_changes, last_git_changes,
         consecutive_idle += 1
         activity = "stalled" if consecutive_idle >= 3 else "idle"
         return activity, consecutive_idle
+
+
+def auto_commit_stranded(worktree_path, stage, logger, *,
+                          reason="stranded files committed",
+                          add_all=False):
+    """Auto-commit any uncommitted changes in the worktree.
+
+    Returns True if a commit was created.
+    """
+    if not worktree_path:
+        return False
+    try:
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree_path, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=10,
+        )
+        if dirty.returncode != 0 or not dirty.stdout.strip():
+            return False
+        add_flag = "-A" if add_all else "-u"
+        subprocess.run(
+            ["git", "add", add_flag], cwd=worktree_path,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=10,
+        )
+        scope = stage.split("-")[0] if "-" in stage else stage
+        msg = f"chore({scope}): auto-commit {reason}"
+        commit = subprocess.run(
+            ["git", "commit", "-m", msg],
+            cwd=worktree_path, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=30,
+        )
+        if commit.returncode == 0:
+            log(logger, stage, "AUTO_COMMIT", reason=reason)
+            return True
+        elif "nothing to commit" not in (commit.stdout + commit.stderr):
+            log(logger, stage, "AUTO_COMMIT_FAILED",
+                reason=commit.stderr.strip()[:200])
+    except (subprocess.TimeoutExpired, OSError):
+        log(logger, stage, "AUTO_COMMIT_FAILED", reason="subprocess error")
+    return False
 
 
 def get_git_activity(worktree_path):
@@ -1238,7 +1289,8 @@ def _read_last_lines(worktree_path, stage_name, n=50):
 
 
 def write_result(worktree_path, status, duration, stages, pr_url=None,
-                  failed_stage=None, error=None, last_output=None):
+                  failed_stage=None, error=None, last_output=None,
+                  resume_command=None):
     """Write pipeline-result.json and invoke notify.py (best-effort)."""
     result = {
         "status": status,
@@ -1253,6 +1305,8 @@ def write_result(worktree_path, status, duration, stages, pr_url=None,
         result["error"] = error
     if last_output is not None:
         result["last_output"] = last_output
+    if resume_command:
+        result["resume_command"] = resume_command
 
     # Include partial QA results from state if QA failed
     if failed_stage and "qa" in failed_stage:
@@ -1597,21 +1651,7 @@ def main():
 
             # Auto-commit stranded files between stages (#717)
             if worktree_path and stage not in ("worktree", "retro", "pr"):
-                dirty = subprocess.run(
-                    ["git", "status", "--porcelain"],
-                    cwd=worktree_path, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
-                )
-                if dirty.returncode == 0 and dirty.stdout.strip():
-                    subprocess.run(["git", "add", "-u"], cwd=worktree_path,
-                                   capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
-                    commit = subprocess.run(
-                        ["git", "commit", "-m", f"chore({stage}): auto-commit stage changes"],
-                        cwd=worktree_path, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30,
-                    )
-                    if commit.returncode == 0:
-                        log(logger, stage, "AUTO_COMMIT", reason="stranded files committed")
-                    elif "nothing to commit" not in (commit.stdout + commit.stderr):
-                        log(logger, stage, "AUTO_COMMIT_FAILED", reason=commit.stderr.strip()[:200])
+                auto_commit_stranded(worktree_path, stage, logger)
 
             # Track stage duration with exit code and last output line
             stage_dur = f"{int(time.time() - stage_start_time)}s"
@@ -1637,11 +1677,31 @@ def main():
         log(logger, "pipeline", "FAILED",
             failed_stage=_failed_stage, reason=_failed_reason,
             duration=f"{duration}s")
+        resume_cmd = None
         if worktree_path:
+            # Auto-commit stranded files on failure (converge STALL_TIMEOUT fix)
+            auto_commit_stranded(
+                worktree_path, _failed_log_stage or _failed_stage, logger,
+                reason="stranded files on pipeline failure",
+                add_all=True,
+            )
+
+            # Compute and emit RESUME_HINT
+            resume_stage = compute_resume_stage(_failed_stage)
+            resume_parts = ["python", "scripts/pipeline.py"]
+            if plan_path:
+                resume_parts.extend(["--plan", source_rel])
+            elif spec_path:
+                resume_parts.extend(["--spec", source_rel, "--branch", branch])
+            resume_parts.extend(["--from", resume_stage,
+                                 "--worktree", worktree_path])
+            resume_cmd = " ".join(resume_parts)
+            log(logger, "pipeline", "RESUME_HINT", command=resume_cmd)
+
             last_output = _read_last_lines(worktree_path, _failed_log_stage, 50)
             write_result(worktree_path, "failed", duration, stage_durations,
                          failed_stage=_failed_stage, error=_failed_reason,
-                         last_output=last_output)
+                         last_output=last_output, resume_command=resume_cmd)
             _result_written = True
 
             # Best-effort failure retro — safe to spawn subprocesses here
@@ -1662,6 +1722,8 @@ def main():
         print(f"\nPipeline FAILED at stage '{_failed_stage}'.", file=sys.stderr)
         if _failed_reason:
             print(f"  Reason: {_failed_reason}", file=sys.stderr)
+        if resume_cmd:
+            print(f"  Resume: {resume_cmd}", file=sys.stderr)
         sys.exit(1)
 
     except KeyboardInterrupt:

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Unit tests for pipeline.py stall-recovery functions.
+
+Usage:
+    python scripts/test_pipeline.py              # run all
+    python -m pytest scripts/test_pipeline.py    # via pytest
+"""
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pipeline import (
+    auto_commit_stranded,
+    classify_activity,
+    compute_resume_stage,
+    should_converge,
+    write_result,
+)
+
+
+class TestAutoCommitStranded(unittest.TestCase):
+
+    def _logger(self):
+        return io.StringIO()
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_clean_worktree_returns_false(self, mock_log, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = auto_commit_stranded("/tmp/wt", "converge", self._logger())
+        self.assertFalse(result)
+        mock_run.assert_called_once()
+        self.assertIn("--porcelain", mock_run.call_args[0][0])
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_dirty_worktree_commits_with_add_u(self, mock_log, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M file.py\n", stderr=""),
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        result = auto_commit_stranded("/tmp/wt", "converge-r1", self._logger())
+        self.assertTrue(result)
+        add_call = mock_run.call_args_list[1]
+        self.assertIn("-u", add_call[0][0])
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_add_all_uses_dash_A(self, mock_log, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M file.py\n", stderr=""),
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        auto_commit_stranded("/tmp/wt", "converge-r1", self._logger(),
+                              add_all=True)
+        add_call = mock_run.call_args_list[1]
+        self.assertIn("-A", add_call[0][0])
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_scope_extracted_from_stage_name(self, mock_log, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M file.py\n", stderr=""),
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        auto_commit_stranded("/tmp/wt", "converge-r1", self._logger())
+        commit_msg = mock_run.call_args_list[2][0][0][-1]
+        self.assertTrue(commit_msg.startswith("chore(converge):"))
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_custom_reason_in_commit_and_log(self, mock_log, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M file.py\n", stderr=""),
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        logger = self._logger()
+        auto_commit_stranded("/tmp/wt", "converge-r1", logger,
+                              reason="stranded files after STALL_TIMEOUT")
+        commit_msg = mock_run.call_args_list[2][0][0][-1]
+        self.assertIn("stranded files after STALL_TIMEOUT", commit_msg)
+        mock_log.assert_called_with(
+            logger, "converge-r1", "AUTO_COMMIT",
+            reason="stranded files after STALL_TIMEOUT")
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_none_worktree_returns_false(self, mock_log, mock_run):
+        result = auto_commit_stranded(None, "converge", self._logger())
+        self.assertFalse(result)
+        mock_run.assert_not_called()
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_commit_failure_returns_false_and_logs(self, mock_log, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M file.py\n", stderr=""),
+            MagicMock(returncode=0),
+            MagicMock(returncode=1, stdout="", stderr="error: something"),
+        ]
+        logger = self._logger()
+        result = auto_commit_stranded("/tmp/wt", "converge", logger)
+        self.assertFalse(result)
+        mock_log.assert_called_with(
+            logger, "converge", "AUTO_COMMIT_FAILED",
+            reason="error: something")
+
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_nothing_to_commit_silent(self, mock_log, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M file.py\n", stderr=""),
+            MagicMock(returncode=0),
+            MagicMock(returncode=1, stdout="nothing to commit", stderr=""),
+        ]
+        result = auto_commit_stranded("/tmp/wt", "converge", self._logger())
+        self.assertFalse(result)
+        mock_log.assert_not_called()
+
+    @patch("pipeline.subprocess.run", side_effect=OSError("disk full"))
+    @patch("pipeline.log")
+    def test_os_error_returns_false(self, mock_log, mock_run):
+        logger = self._logger()
+        result = auto_commit_stranded("/tmp/wt", "converge", logger)
+        self.assertFalse(result)
+        mock_log.assert_called_with(
+            logger, "converge", "AUTO_COMMIT_FAILED",
+            reason="subprocess error")
+
+
+class TestComputeResumeStage(unittest.TestCase):
+
+    def test_direct_stages_returned_as_is(self):
+        for stage in ["implement", "gates", "verify", "qa", "review",
+                       "converge", "pr", "retro"]:
+            self.assertEqual(compute_resume_stage(stage), stage)
+
+    def test_reconverge_variants_map_to_converge(self):
+        for name in ["gates-reconverge", "verify-reconverge",
+                      "qa-reconverge", "review-reconverge"]:
+            self.assertEqual(compute_resume_stage(name), "converge",
+                             msg=f"{name} should map to converge")
+
+    def test_retry_suffix_maps_to_base(self):
+        self.assertEqual(compute_resume_stage("implement-retry"), "implement")
+        self.assertEqual(compute_resume_stage("verify-retry"), "verify")
+
+    def test_unknown_stage_returned_as_is(self):
+        self.assertEqual(compute_resume_stage("unknown-stage"), "unknown-stage")
+
+
+class TestWriteResultResumeCommand(unittest.TestCase):
+
+    def test_resume_command_included(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wf = os.path.join(tmpdir, ".workflow")
+            os.makedirs(wf)
+            cmd = "python scripts/pipeline.py --from converge --worktree /tmp/wt"
+            write_result(tmpdir, "failed", 100, {},
+                         failed_stage="converge", resume_command=cmd)
+            with open(os.path.join(wf, "pipeline-result.json")) as f:
+                data = json.load(f)
+            self.assertEqual(data["resume_command"], cmd)
+            self.assertEqual(data["status"], "failed")
+            self.assertEqual(data["failed_stage"], "converge")
+
+    def test_resume_command_absent_on_success(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wf = os.path.join(tmpdir, ".workflow")
+            os.makedirs(wf)
+            write_result(tmpdir, "complete", 100, {})
+            with open(os.path.join(wf, "pipeline-result.json")) as f:
+                data = json.load(f)
+            self.assertNotIn("resume_command", data)
+
+    def test_resume_command_absent_when_none(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wf = os.path.join(tmpdir, ".workflow")
+            os.makedirs(wf)
+            write_result(tmpdir, "failed", 100, {},
+                         failed_stage="converge", resume_command=None)
+            with open(os.path.join(wf, "pipeline-result.json")) as f:
+                data = json.load(f)
+            self.assertNotIn("resume_command", data)
+
+
+class TestClassifyActivityPreserved(unittest.TestCase):
+
+    def test_output_growth_resets_idle(self):
+        activity, idle = classify_activity(200, 100, 0, 0, 1, 1, 3)
+        self.assertEqual(activity, "active")
+        self.assertEqual(idle, 0)
+
+    def test_git_growth_resets_idle(self):
+        activity, idle = classify_activity(100, 100, 5, 3, 1, 1, 3)
+        self.assertEqual(activity, "active")
+        self.assertEqual(idle, 0)
+
+    def test_commit_growth_resets_idle(self):
+        activity, idle = classify_activity(100, 100, 0, 0, 5, 3, 3)
+        self.assertEqual(activity, "active")
+        self.assertEqual(idle, 0)
+
+    def test_children_resets_idle(self):
+        activity, idle = classify_activity(100, 100, 0, 0, 1, 1, 3,
+                                           has_children=True)
+        self.assertEqual(activity, "active")
+        self.assertEqual(idle, 0)
+
+    def test_no_activity_increments_idle(self):
+        activity, idle = classify_activity(100, 100, 0, 0, 1, 1, 0)
+        self.assertEqual(activity, "idle")
+        self.assertEqual(idle, 1)
+
+    def test_stalled_after_three_idle(self):
+        activity, idle = classify_activity(100, 100, 0, 0, 1, 1, 2)
+        self.assertEqual(activity, "stalled")
+        self.assertEqual(idle, 3)
+
+
+class TestShouldConvergePreserved(unittest.TestCase):
+
+    def test_passed_no_findings_skips(self):
+        run, _ = should_converge({"review": {"passed": True, "findings": 0}})
+        self.assertFalse(run)
+
+    def test_passed_with_findings_triggers(self):
+        run, _ = should_converge({"review": {"passed": True, "findings": 5}})
+        self.assertTrue(run)
+
+    def test_not_passed_triggers(self):
+        run, _ = should_converge({"review": {"passed": False}})
+        self.assertTrue(run)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Auto-commit on failure:** Extract `auto_commit_stranded()` helper and call it (with `git add -A`) in the `PipelineFailure` handler so files modified by an agent are never stranded when STALL_TIMEOUT fires — fixes the PR #956 converge scenario where 14 files were left uncommitted
- **RESUME_HINT:** On any pipeline failure, emit a `RESUME_HINT` log line and print the resume command to stderr; also write `resume_command` to `pipeline-result.json` for programmatic use
- **`compute_resume_stage()`:** Maps sub-stage names (`gates-reconverge`, `converge-r1`, etc.) back to valid `--from` targets so the resume command is always correct

Ref: PR #956 retro — converge-r1 STALL_TIMEOUT stranded 14 modified files

## Test Plan

- [x] 25 unit tests in `scripts/test_pipeline.py` covering:
  - `auto_commit_stranded()`: clean worktree, dirty worktree, `-A` vs `-u`, custom reason, commit failure, OSError
  - `compute_resume_stage()`: direct stages, reconverge variants, retry suffix, unknown stage
  - `write_result()`: resume_command present/absent in JSON output
  - `classify_activity()` and `should_converge()`: regression tests ensuring existing behavior preserved
- [x] `verify-workflow.py` scenarios: 9/9 pass
- [x] .NET build: 0 errors
- [x] .NET tests: 0 failures

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)