### PR TITLE
fix(monitor): continue to Gemini triage on CI failure (#860)

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -962,11 +962,12 @@ def run_monitor(worktree, pr_number, resume=False):
 
             if ci_status == "fail":
                 result["status"] = "ci_failed"
-                _step_notify(worktree, pr_number, logger, result)
                 write_result(worktree, result)
-                logger.log("monitor", "ABORT", reason="CI failed")
-                logger.close()
-                return 1
+                _notify_terminal(worktree, pr_number, logger,
+                                 f"PR #{pr_number} CI failed — "
+                                 f"continuing to triage")
+                logger.log("monitor", "CI_FAILED_CONTINUE",
+                           reason="CI failed, proceeding to Gemini/triage")
 
             if ci_status == "timeout":
                 result["status"] = "ci_timeout"
@@ -1029,12 +1030,15 @@ def run_monitor(worktree, pr_number, resume=False):
 
             if ci_status == "fail":
                 result["status"] = "ci_failed"
-                _step_notify(worktree, pr_number, logger, result)
                 write_result(worktree, result)
-                logger.log("monitor", "ABORT",
-                           reason=f"CI failed after triage round {triage_iteration}")
-                logger.close()
-                return 1
+                _notify_terminal(
+                    worktree, pr_number, logger,
+                    f"PR #{pr_number} CI failed after triage round "
+                    f"{triage_iteration}")
+                logger.log("monitor", "CI_FAILED_CONTINUE",
+                           reason=f"CI failed after triage round "
+                           f"{triage_iteration}, exiting triage loop")
+                break
 
             if ci_status == "timeout":
                 result["status"] = "ci_timeout"
@@ -1072,6 +1076,15 @@ def run_monitor(worktree, pr_number, resume=False):
                        round=triage_iteration, comments=len(comments))
             inline_count = len(comments)
 
+        # Triage-complete notification when CI was failing (#860)
+        if result.get("ci_result") == "fail" and result.get("triage_summary"):
+            total = sum(len(s.get("results", []))
+                        for s in result["triage_summary"])
+            _notify_terminal(
+                worktree, pr_number, logger,
+                f"PR #{pr_number} triage complete — "
+                f"{total} item(s) triaged (CI still failing)")
+
         # ---- Step 4: Mark PR ready ----
         if not (resume and step_completed(result, "ready")):
             _step_ready(worktree, pr_number, logger, result)
@@ -1083,6 +1096,13 @@ def run_monitor(worktree, pr_number, resume=False):
         # ---- Step 6: Notify ----
         if not (resume and step_completed(result, "notify")):
             _step_notify(worktree, pr_number, logger, result)
+
+        if result.get("ci_result") == "fail":
+            result["status"] = "ci_failed"
+            write_result(worktree, result)
+            logger.log("monitor", "COMPLETE_CI_FAILED", pr=pr_number)
+            logger.close()
+            return 1
 
         result["status"] = "complete"
         write_result(worktree, result)

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -1093,16 +1093,20 @@ def run_monitor(worktree, pr_number, resume=False):
         if not (resume and step_completed(result, "retro")):
             _step_retro(worktree, logger, result)
 
-        # ---- Step 6: Notify ----
-        if not (resume and step_completed(result, "notify")):
-            _step_notify(worktree, pr_number, logger, result)
-
+        # Exit early on CI failure — _step_ready already sent a descriptive
+        # notification explaining why the PR remains in draft. Skipping
+        # _step_notify avoids a misleading "PR is ready" message right
+        # before the monitor exits with an error code.
         if result.get("ci_result") == "fail":
             result["status"] = "ci_failed"
             write_result(worktree, result)
             logger.log("monitor", "COMPLETE_CI_FAILED", pr=pr_number)
             logger.close()
             return 1
+
+        # ---- Step 6: Notify ----
+        if not (resume and step_completed(result, "notify")):
+            _step_notify(worktree, pr_number, logger, result)
 
         result["status"] = "complete"
         write_result(worktree, result)

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -86,25 +86,119 @@ class TestCiFailure:
         assert result == "fail"
 
     def test_ci_failure_triggers_notify_in_monitor(self, tmp_path):
-        """run_monitor writes status=ci_failed and calls notify on CI failure."""
+        """run_monitor writes status=ci_failed, continues to triage, and
+        still returns exit code 1 (#860)."""
         wt = _make_worktree(tmp_path)
 
-        checks_fail = [
-            {"name": "build", "state": "COMPLETED", "bucket": "fail"},
-        ]
-
-        with patch("pr_monitor.subprocess.run", return_value=_gh_checks_json(checks_fail)), \
+        with patch("pr_monitor.poll_ci", return_value="fail"), \
+             patch("pr_monitor.poll_gemini_comments", return_value=[]), \
+             patch("pr_monitor.run_retro", return_value="done"), \
              patch("pr_monitor.run_notify") as mock_notify:
             exit_code = pr_monitor.run_monitor(wt, 99, resume=False)
 
         assert exit_code == 1
         result = pr_monitor.read_result(wt)
         assert result["status"] == "ci_failed"
-        mock_notify.assert_called_once()
-        # Verify worktree and PR number are passed to notification
-        notify_args = mock_notify.call_args
-        assert notify_args[0][0] == wt, "run_notify must receive worktree path"
-        assert notify_args[0][1] == 99, "run_notify must receive PR number"
+        # CI-fail notification + final notification (#860: no longer aborts)
+        assert mock_notify.call_count >= 1
+        # First call is the CI-fail terminal notification
+        first_call = mock_notify.call_args_list[0]
+        assert first_call[0][0] == wt, "run_notify must receive worktree path"
+        assert first_call[0][1] == 99, "run_notify must receive PR number"
+        assert "CI failed" in first_call[1].get("message", "")
+
+
+class TestCiFailContinuesToTriage:
+    """#860: CI failure must not abort triage — Gemini comments are still triaged."""
+
+    def test_ci_fail_then_gemini_comment_is_triaged(self, tmp_path):
+        """AC-4: CI fails, Gemini posts a comment, monitor triages it."""
+        wt = _make_worktree(tmp_path)
+        pr_monitor._POSTED_REPLY_KEYS.clear()
+
+        gemini_comment = {
+            "id": 7001, "user": "gemini-code-assist[bot]",
+            "path": "src/Risky.cs", "line": 42,
+            "body": "File.Create race condition — use SetUnixFileMode",
+        }
+        triage_result = [{
+            "id": 7001, "action": "acknowledged",
+            "description": "security finding acknowledged",
+        }]
+
+        with patch("pr_monitor.poll_ci", return_value="fail"), \
+             patch("pr_monitor.poll_gemini_comments",
+                   return_value=[gemini_comment]), \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]), \
+             patch("pr_monitor.run_triage", return_value=triage_result) as mock_triage, \
+             patch("pr_monitor._post_replies_common"), \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify") as mock_notify:
+            exit_code = pr_monitor.run_monitor(wt, 858, resume=False)
+
+        assert exit_code == 1
+        result = pr_monitor.read_result(wt)
+        assert result["status"] == "ci_failed"
+
+        # AC-1: triage ran despite CI failure
+        mock_triage.assert_called_once()
+
+        # AC-3: CI-fail notification AND triage-complete notification
+        notify_messages = [
+            c[1].get("message", "") for c in mock_notify.call_args_list
+            if c[1].get("message")
+        ]
+        assert any("CI failed" in m for m in notify_messages), \
+            "CI-fail notification missing"
+        assert any("triage complete" in m for m in notify_messages), \
+            "triage-complete notification missing"
+
+        # AC-2: ready-flip was NOT performed (CI is failing)
+        assert result["steps_completed"].get("ready", {}).get("status") == "skipped"
+
+    def test_ci_fail_no_gemini_comments_still_completes(self, tmp_path):
+        """CI fails with no Gemini comments — triage is skipped, status=ci_failed."""
+        wt = _make_worktree(tmp_path)
+
+        with patch("pr_monitor.poll_ci", return_value="fail"), \
+             patch("pr_monitor.poll_gemini_comments", return_value=[]), \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify"):
+            exit_code = pr_monitor.run_monitor(wt, 100, resume=False)
+
+        assert exit_code == 1
+        result = pr_monitor.read_result(wt)
+        assert result["status"] == "ci_failed"
+        assert result["triage_summary"] == []
+
+    def test_ci_fail_ready_flip_gated(self, tmp_path):
+        """AC-2: ready-flip is correctly gated on CI passing, no regression of #834."""
+        wt = _make_worktree(tmp_path)
+
+        with patch("pr_monitor.poll_ci", return_value="fail"), \
+             patch("pr_monitor.poll_gemini_comments", return_value=[]), \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify"), \
+             patch("pr_monitor.mark_pr_ready") as mock_ready:
+            exit_code = pr_monitor.run_monitor(wt, 101, resume=False)
+
+        assert exit_code == 1
+        mock_ready.assert_not_called()
+
+    def test_gemini_timeout_still_applies_on_ci_fail(self, tmp_path):
+        """AC-5: existing Gemini-review timeout still applies when CI fails."""
+        wt = _make_worktree(tmp_path)
+
+        with patch("pr_monitor.poll_ci", return_value="fail"), \
+             patch("pr_monitor.poll_gemini_comments", return_value=[]) as mock_gemini, \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify"):
+            exit_code = pr_monitor.run_monitor(wt, 102, resume=False)
+
+        assert exit_code == 1
+        # poll_gemini_comments was called (not skipped), proving
+        # the Gemini wait phase ran even though CI failed.
+        mock_gemini.assert_called_once()
 
 
 class TestCiTimeout:


### PR DESCRIPTION
## Summary
- Remove two early `return 1` statements in `pr_monitor.py` that aborted the entire monitor lifecycle on CI failure, skipping Gemini comment wait and triage
- On CI fail, the monitor now proceeds through Gemini wait, triage, retro, and notify — only the ready-flip remains gated on CI passing (no regression of #834)
- Adds triage-complete notification when CI failed and triage found items

Closes #860

## Test Plan
- [x] `test_ci_fail_then_gemini_comment_is_triaged` — AC-4: CI fails, Gemini posts comment, monitor triages it
- [x] `test_ci_fail_no_gemini_comments_still_completes` — CI fail with no comments still completes
- [x] `test_ci_fail_ready_flip_gated` — AC-2: `mark_pr_ready` never called when CI failing
- [x] `test_gemini_timeout_still_applies_on_ci_fail` — AC-5: Gemini poll runs despite CI fail
- [x] Updated `test_ci_failure_triggers_notify_in_monitor` — adapted for continue-to-triage behavior
- [x] All 79 tests pass

## Verification
- [x] /gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)