### PR TITLE
fix(pipeline): detect grandchild processes in stall detection (#964, #965)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -17,6 +17,10 @@ pipeline orchestrator. In pipeline mode:
 - Execute Steps 1-5 only (plan analysis through phase execution)
 - Skip Step 6 (Mandatory Tail) — the pipeline orchestrator runs gates/verify/qa/review
   as separate `claude -p` sessions with their own timeouts and monitoring
+- **Do NOT use `ScheduleWakeup`** — the pipeline monitors parent-process output to detect
+  stalls. A sleeping parent produces no output and will be killed. Instead, dispatch agents
+  in foreground (`run_in_background: false`) or poll background agents with `TaskOutput`
+  at ≤60 s intervals so the parent transcript keeps growing.
 - Exit cleanly after all phases are committed
 
 In interactive mode (`PPDS_PIPELINE` not set), execute the full process including Step 6.

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -306,8 +306,8 @@ def release_lock(lock_path):
         pass
 
 
-def get_child_process_count(pid):
-    """Count active child processes of a given PID."""
+def _get_direct_children(pid):
+    """Return list of direct child PIDs for *pid*."""
     try:
         if sys.platform == "win32":
             result = subprocess.run(
@@ -317,9 +317,8 @@ def get_child_process_count(pid):
                 encoding="utf-8", errors="replace",
             )
             if result.returncode == 0:
-                lines = [l.strip() for l in result.stdout.strip().splitlines()
-                         if l.strip().isdigit()]
-                return len(lines)
+                return [int(l.strip()) for l in result.stdout.strip().splitlines()
+                        if l.strip().isdigit()]
         else:
             result = subprocess.run(
                 ["pgrep", "-P", str(pid)],
@@ -327,10 +326,24 @@ def get_child_process_count(pid):
                 encoding="utf-8", errors="replace",
             )
             if result.returncode == 0:
-                return len(result.stdout.strip().splitlines())
+                return [int(l.strip()) for l in result.stdout.strip().splitlines()
+                        if l.strip()]
     except (subprocess.TimeoutExpired, FileNotFoundError, ValueError, OSError):
         pass
-    return 0
+    return []
+
+
+def get_child_process_count(pid):
+    """Count all descendant processes of *pid* (children, grandchildren, …)."""
+    visited = set()
+    queue = [pid]
+    while queue:
+        current = queue.pop()
+        for child in _get_direct_children(current):
+            if child not in visited:
+                visited.add(child)
+                queue.append(child)
+    return len(visited)
 
 
 def classify_activity(current_size, last_size, git_changes, last_git_changes,

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -17,9 +17,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import pipeline
 from pipeline import (
     STAGE_MODELS,
+    _get_direct_children,
     auto_commit_stranded,
     classify_activity,
     compute_resume_stage,
+    get_child_process_count,
     should_converge,
     write_result,
 )
@@ -50,7 +52,7 @@ class TestAutoCommitStranded(unittest.TestCase):
         result = auto_commit_stranded("/tmp/wt", "converge-r1", self._logger())
         self.assertTrue(result)
         add_call = mock_run.call_args_list[1]
-        self.assertIn("-u", add_call[0][0])
+        self.assertIn("-A", add_call[0][0])
 
     @patch("pipeline.subprocess.run")
     @patch("pipeline.log")
@@ -227,6 +229,55 @@ class TestClassifyActivityPreserved(unittest.TestCase):
         activity, idle = classify_activity(100, 100, 0, 0, 1, 1, 2)
         self.assertEqual(activity, "stalled")
         self.assertEqual(idle, 3)
+
+
+class TestDescendantProcessCount(unittest.TestCase):
+    """Verify get_child_process_count walks the full process tree (#964)."""
+
+    @patch("pipeline._get_direct_children")
+    def test_counts_grandchildren(self, mock_children):
+        # Tree: pid 1 -> [2, 3], pid 2 -> [4], pid 3 -> [], pid 4 -> []
+        mock_children.side_effect = lambda pid: {
+            1: [2, 3],
+            2: [4],
+            3: [],
+            4: [],
+        }.get(pid, [])
+        self.assertEqual(get_child_process_count(1), 3)  # 2, 3, 4
+
+    @patch("pipeline._get_direct_children")
+    def test_no_children_returns_zero(self, mock_children):
+        mock_children.return_value = []
+        self.assertEqual(get_child_process_count(99), 0)
+
+    @patch("pipeline._get_direct_children")
+    def test_only_direct_children(self, mock_children):
+        mock_children.side_effect = lambda pid: {
+            10: [11, 12],
+            11: [],
+            12: [],
+        }.get(pid, [])
+        self.assertEqual(get_child_process_count(10), 2)
+
+    @patch("pipeline._get_direct_children")
+    def test_deep_tree(self, mock_children):
+        # Linear chain: 1 -> 2 -> 3 -> 4 -> 5
+        mock_children.side_effect = lambda pid: {
+            1: [2], 2: [3], 3: [4], 4: [5], 5: [],
+        }.get(pid, [])
+        self.assertEqual(get_child_process_count(1), 4)  # 2, 3, 4, 5
+
+    @patch("pipeline._get_direct_children")
+    def test_grandchild_active_classifies_as_active(self, mock_children):
+        """Parent silent + grandchild active -> 'active' not 'stalled'."""
+        mock_children.side_effect = lambda pid: {
+            1: [2], 2: [3], 3: [],
+        }.get(pid, [])
+        count = get_child_process_count(1)
+        activity, idle = classify_activity(
+            100, 100, 0, 0, 1, 1, 4, has_children=count > 0)
+        self.assertEqual(activity, "active")
+        self.assertEqual(idle, 0)
 
 
 class TestShouldConvergePreserved(unittest.TestCase):


### PR DESCRIPTION
## Summary
- **#964 structural fix:** `get_child_process_count` now BFS-walks the full process tree (children, grandchildren, …) instead of only counting direct children. Background Agent subprocesses dispatched by the implement skill are now detected as active work, preventing false stall kills.
- **#965 belt fix:** Added a `ScheduleWakeup` prohibition to the implement skill's pipeline-mode block — when `PPDS_PIPELINE=1`, agents must run in foreground or poll with `TaskOutput` at ≤60s intervals.
- 5 new tests in `TestDescendantProcessCount` covering grandchild counting, empty trees, direct-only, deep chains, and the end-to-end integration (grandchild active → classify_activity returns "active").
- Fixed a pre-existing stale assertion in `test_dirty_worktree_commits_with_add_u` (`-u` → `-A`).

Closes #964, closes #965

## Test plan
- [x] `python scripts/test_pipeline.py` — 35/35 pass
- [x] `python scripts/audit-enforcement.py --strict` — 11 T1 markers, all wired
- [x] Existing `TestClassifyActivityPreserved` regression suite passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)