### PR TITLE
fix(triage): iterate bracket positions in parse_triage_json

### DIFF
--- a/scripts/test_audit_enforcement.py
+++ b/scripts/test_audit_enforcement.py
@@ -64,7 +64,7 @@ def _make_fake_repo(skill_files: dict[str, str], hook_names: list[str],
 def _run(repo: str, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(SCRIPT), "--repo-root", repo, *args],
-        capture_output=True, text=True, timeout=30,
+        capture_output=True, text=True, timeout=30, stdin=subprocess.DEVNULL,
     )
 
 
@@ -224,6 +224,7 @@ class TestAllT1DirectivesMarked(unittest.TestCase):
         proc = subprocess.run(
             [sys.executable, str(SCRIPT), "--discover"],
             cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=30,
+            stdin=subprocess.DEVNULL,
         )
         self.assertEqual(
             proc.returncode, 0,

--- a/scripts/test_hooks.py
+++ b/scripts/test_hooks.py
@@ -60,13 +60,15 @@ def _make_state(project_dir: str, state: dict) -> str:
 
 def _git_init_branch(project_dir: str, branch: str = "feat/x"):
     """Make project_dir look enough like a git repo to satisfy the stop hook."""
-    subprocess.run(["git", "init", "-q", "-b", branch], cwd=project_dir, check=True)
+    subprocess.run(["git", "init", "-q", "-b", branch], cwd=project_dir, check=True,
+                   stdin=subprocess.DEVNULL)
     subprocess.run(["git", "config", "user.email", "test@example.com"],
-                   cwd=project_dir, check=True)
-    subprocess.run(["git", "config", "user.name", "test"], cwd=project_dir, check=True)
+                   cwd=project_dir, check=True, stdin=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=project_dir, check=True,
+                   stdin=subprocess.DEVNULL)
     # Empty initial commit so HEAD exists
     subprocess.run(["git", "commit", "--allow-empty", "-q", "-m", "init"],
-                   cwd=project_dir, check=True)
+                   cwd=project_dir, check=True, stdin=subprocess.DEVNULL)
 
 
 # ---------------------------------------------------------------------------
@@ -120,14 +122,15 @@ class TestStopHookPrInvocationGate(unittest.TestCase):
         _git_init_branch(tmp, "feat/x")
         # Stub origin/main to current HEAD (no commits ahead) by default.
         head = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=tmp, capture_output=True, text=True
+            ["git", "rev-parse", "HEAD"], cwd=tmp, capture_output=True, text=True,
+            stdin=subprocess.DEVNULL,
         ).stdout.strip()
         subprocess.run(["git", "update-ref", "refs/remotes/origin/main", head],
-                       cwd=tmp, check=True)
+                       cwd=tmp, check=True, stdin=subprocess.DEVNULL)
         for i in range(ahead):
             subprocess.run(
                 ["git", "commit", "--allow-empty", "-q", "-m", f"c{i}"],
-                cwd=tmp, check=True,
+                cwd=tmp, check=True, stdin=subprocess.DEVNULL,
             )
         _make_state(tmp, state)
         return tmp

--- a/scripts/test_parsing_brittleness.py
+++ b/scripts/test_parsing_brittleness.py
@@ -112,18 +112,18 @@ class TestLaunchPromptSafety(unittest.TestCase):
         self.assertIn("'@ midline", script)
 
     def test_terminator_at_line_start_rejected(self):
-        prompt = "Line1\n'@ this would break\nLine3"
+        prompt = "Line1\n'@\nLine3"
         with self.assertRaises(ValueError):
             launch_claude_session.build_launch_script(
                 r"C:\repo", r"C:\bin\claude.exe", prompt,
             )
 
-    def test_indented_terminator_rejected(self):
-        prompt = "Line1\n  '@ indented also breaks\nLine3"
-        with self.assertRaises(ValueError):
-            launch_claude_session.build_launch_script(
-                r"C:\repo", r"C:\bin\claude.exe", prompt,
-            )
+    def test_terminator_with_trailing_text_allowed(self):
+        prompt = "Line1\n'@ this is fine in PowerShell\nLine3"
+        script = launch_claude_session.build_launch_script(
+            r"C:\repo", r"C:\bin\claude.exe", prompt,
+        )
+        self.assertIn("'@ this is fine", script)
 
     def test_prompt_stdin_dry_run(self):
         prompt = "Test with – em-dash and $(whoami)"
@@ -141,6 +141,50 @@ class TestLaunchPromptSafety(unittest.TestCase):
                 content = f.read()
             self.assertIn("$(whoami)", content)
             self.assertIn("–", content)
+
+
+class TestParseTriageJson(unittest.TestCase):
+    """parse_triage_json must find the JSON array even when description
+    strings contain '[' characters (e.g. regex patterns)."""
+
+    def test_bracket_in_description_does_not_break_parse(self):
+        from triage_common import parse_triage_json
+        content = (
+            'Here are the triage results:\n'
+            '```json\n'
+            '[{"id": 1, "action": "fixed", '
+            '"description": "Changed regex [ \\\\t]*\'@ to exact match", '
+            '"commit": "abc123"}]\n'
+            '```'
+        )
+        result = parse_triage_json(content)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], 1)
+
+    def test_multiple_brackets_in_descriptions(self):
+        from triage_common import parse_triage_json
+        content = (
+            '[{"id": 1, "action": "dismissed", '
+            '"description": "Regex [a-z]+ is fine", "commit": null}, '
+            '{"id": 2, "action": "fixed", '
+            '"description": "Changed [old] to [new]", "commit": "def456"}]'
+        )
+        result = parse_triage_json(content)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 2)
+
+    def test_no_json_returns_none(self):
+        from triage_common import parse_triage_json
+        self.assertIsNone(parse_triage_json("no json here"))
+        self.assertIsNone(parse_triage_json(""))
+
+    def test_plain_array_without_fences(self):
+        from triage_common import parse_triage_json
+        content = '[{"id": 1, "action": "fixed", "description": "done", "commit": "abc"}]'
+        result = parse_triage_json(content)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0]["action"], "fixed")
 
 
 class TestNoBareOpen(unittest.TestCase):

--- a/scripts/triage_common.py
+++ b/scripts/triage_common.py
@@ -310,15 +310,19 @@ def parse_triage_json(content):
     Works for both direct stage log content (pipeline) and
     pre-extracted text (pr_monitor). Returns list or None.
     """
-    last_bracket = content.rfind("[")
-    if last_bracket != -1:
+    decoder = json.JSONDecoder()
+    search_from = len(content)
+    while search_from > 0:
+        pos = content.rfind("[", 0, search_from)
+        if pos == -1:
+            return None
         try:
-            decoder = json.JSONDecoder()
-            obj, _ = decoder.raw_decode(content[last_bracket:])
+            obj, _ = decoder.raw_decode(content[pos:])
             if isinstance(obj, list):
                 return obj
         except (json.JSONDecodeError, ValueError):
             pass
+        search_from = pos
     return None
 
 


### PR DESCRIPTION
## Summary

- **fix(triage):** `parse_triage_json` used `rfind("[")` to find the JSON array, which grabbed `[` characters inside description strings (e.g. regex `[ \t]*'@`), causing parse failures and wasted triage rounds. Now iterates backwards through `[` positions trying `raw_decode` at each until one parses as a valid list.
- **fix(tests):** Added `stdin=subprocess.DEVNULL` to all `subprocess.run` calls in `test_hooks.py` and `test_audit_enforcement.py` that don't specify `stdin`/`input`. Fixes 12 `WinError 6` failures in headless environments (Python 3.14 + Windows).
- **fix(tests):** Aligned 2 terminator tests with the exact-equality check merged in #981 (`test_terminator_at_line_start_rejected` and `test_terminator_with_trailing_text_allowed`).

## Root Cause (triage parse)

PR #981's monitor run had a round-1 triage failure: the triage agent's description included `[ \t]*'@` (a regex pattern). `content.rfind("[")` found this `[` at position 2238 instead of the JSON array's `[` at position ~185. `raw_decode` then tried to parse `[ \t]*'@...` as JSON → failed → `PARSE_FAILED`. Round 2 self-healed because its descriptions used different wording without `[`.

## Root Cause (WinError 6)

In Claude Code's headless agent environment, the parent process's stdin handle is invalid. `subprocess.run` without `stdin=` inherits this handle; Python 3.14's `_get_handles` then calls `DuplicateHandle` on it → `OSError: [WinError 6] The handle is invalid`. Same bug class fixed in `test_parsing_brittleness.py` by PR #981.

## Test Plan

- [x] 124/124 Python tests pass (0 failures, vs 12 WinError 6 failures before)
- [x] 4 new `TestParseTriageJson` tests cover: bracket-in-description, multiple brackets, no-json, plain array
- [x] Enforcement audit passes (11 T1 markers)
- [x] 9/9 workflow scenarios pass

## Verification

- [x] /gates passed
- [x] /verify workflow completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
