### PR TITLE
test(cli): expand E2E coverage for data migration commands (#104)

### DIFF
--- a/.retros/2026-04-26-summary.md
+++ b/.retros/2026-04-26-summary.md
@@ -1,0 +1,39 @@
+# Retro: feat/cli-e2e-data-migration — 2026-04-26
+
+**Branch:** feat/cli-e2e-data-migration  
+**PR:** #985 — test(cli): expand E2E coverage for data migration commands (#104)  
+**Severity:** clean  
+**Commits on branch:** 3 (+ 1 fix from this retro)  
+**Fix ratio:** 0.75 post-retro  
+
+## Pattern Narrative
+
+A clean session: E2E tests for data export, import, and full migration round-trip were added, then review findings were addressed quickly (6m and 14m cadence). The only material issue was a test authoring mistake — filter expressions were written in OData syntax (`eq`) but `data schema --filter` documents and enforces SQL syntax (`=`). All 5 live-test failures shared identical stack traces pointing to this single cause.
+
+## Top Finding
+
+| ID | Description | Tier | Kind | Status |
+|----|-------------|------|------|--------|
+| R-01 | 5 live CI tests fail: `--filter "account:name eq 'X'"` passes OData `eq` to a SQL parser | issue-only | code | **landed** (commit `9e67053d3`) |
+
+**Root cause:** `SchemaCommand.cs:65` describes "SQL-like filter … e.g., `account:statecode = 0`" but test author used OData operator `eq` instead of `=`. Five test methods in two files — `DataMigrationWorkflowE2ETests.cs` (2) and `DataImportCommandE2ETests.cs` (3).
+
+**Contributing factors:** `behavior` (wrong operator chosen), `skill` (SQL vs OData distinction not surfaced in CLI help text).
+
+**Fix:** Replaced all 5 `eq` occurrences with `=` and pushed to trigger CI re-run.
+
+## Decisions Log
+
+| ID | Verb | Route | Status |
+|----|------|-------|--------|
+| R-01 | DO NOW | Lane B (fix agent) → push | landed |
+
+## What Worked
+
+- Gemini review caught the unused `_testPrefix` field in the first pass.
+- 6m/14m review-iteration cadence shows a tight feedback loop.
+- Mechanical extraction cleanly identified the 5 identical CI failures without ambiguity.
+
+## Meta
+
+No meta-recommendations this session. Recurring `tooling` pattern from prior retros is not represented here — this session was purely test quality.

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "last_updated": "2026-04-26",
-  "total_retros": 12,
+  "total_retros": 13,
   "findings_by_category": {
     "external": [
       {
@@ -304,11 +304,18 @@
         "branch": "verify/v1-shakedown",
         "finding_id": "R-05"
       }
+    ],
+    "code": [
+      {
+        "date": "2026-04-26",
+        "branch": "feat/cli-e2e-data-migration",
+        "finding_id": "R-01"
+      }
     ]
   },
   "metrics": {
     "avg_fix_ratio": 0.749,
-    "pipeline_success_rate": 0.370,
-    "avg_convergence_rounds": 2.41
+    "pipeline_success_rate": 0.418,
+    "avg_convergence_rounds": 2.302
   }
 }

--- a/tests/PPDS.LiveTests/Cli/DataExportCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataExportCommandE2ETests.cs
@@ -1,0 +1,246 @@
+using FluentAssertions;
+using PPDS.LiveTests.Infrastructure;
+
+namespace PPDS.LiveTests.Cli;
+
+/// <summary>
+/// E2E tests for ppds data export command.
+/// Exports data from Dataverse to a ZIP file based on a schema.
+/// Tests only run on .NET 8.0 since CLI is spawned with --framework net8.0.
+/// </summary>
+public class DataExportCommandE2ETests : CliE2ETestBase
+{
+    /// <summary>
+    /// Unique identifier prefix for test artifacts to avoid conflicts.
+    /// </summary>
+    private readonly string _testPrefix = $"PPDS_E2EExport_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Profile name used across Tier 2 tests in this class.
+    /// </summary>
+    private string? _profileName;
+
+    #region Tier 1: Validation tests (no credentials needed)
+
+    [CliE2EFact]
+    public async Task Export_MissingSchema_FailsWithError()
+    {
+        var outputPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--output", outputPath);
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("--schema", "required");
+    }
+
+    [CliE2EFact]
+    public async Task Export_MissingOutput_FailsWithError()
+    {
+        var schemaPath = GenerateTempFilePath(".xml");
+        await File.WriteAllTextAsync(schemaPath, "<entities/>");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath);
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("--output", "required");
+    }
+
+    [CliE2EFact]
+    public async Task Export_SchemaFileNotFound_FailsWithError()
+    {
+        var nonexistentSchema = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid():N}.xml");
+        var outputPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", nonexistentSchema,
+            "--output", outputPath);
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("does not exist", "not found", "Error");
+    }
+
+    [CliE2EFact]
+    public async Task Export_OutputDirectoryNotExists_FailsWithError()
+    {
+        var schemaPath = GenerateTempFilePath(".xml");
+        await File.WriteAllTextAsync(schemaPath, "<entities/>");
+
+        // Construct an output path whose parent directory does not exist
+        var outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "file.zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", outputPath);
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("directory");
+    }
+
+    [CliE2EFact]
+    public async Task Export_InvalidBatchSize_FailsWithError()
+    {
+        var schemaPath = GenerateTempFilePath(".xml");
+        await File.WriteAllTextAsync(schemaPath, "<entities/>");
+        var outputPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", outputPath,
+            "--batch-size", "0");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("batch-size");
+    }
+
+    [CliE2EFact]
+    public async Task Export_BatchSizeExceedsMax_FailsWithError()
+    {
+        var schemaPath = GenerateTempFilePath(".xml");
+        await File.WriteAllTextAsync(schemaPath, "<entities/>");
+        var outputPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", outputPath,
+            "--batch-size", "6000");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("5000", "batch-size");
+    }
+
+    [CliE2EFact]
+    public async Task Export_InvalidParallel_FailsWithError()
+    {
+        var schemaPath = GenerateTempFilePath(".xml");
+        await File.WriteAllTextAsync(schemaPath, "<entities/>");
+        var outputPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", outputPath,
+            "--parallel", "0");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("parallel");
+    }
+
+    #endregion
+
+    #region Tier 2: Live Dataverse tests
+
+    [CliE2EWithCredentials]
+    public async Task Export_ValidSchema_CreatesZipFile()
+    {
+        await EnsureProfileAsync();
+
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath);
+
+        schemaResult.ExitCode.Should().Be(0, $"Schema generation StdErr: {schemaResult.StdErr}");
+
+        var zipPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        File.Exists(zipPath).Should().BeTrue("Export ZIP file should be created");
+        new FileInfo(zipPath).Length.Should().BeGreaterThan(0, "Export ZIP file should not be empty");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Export_JsonFormat_OutputsProgress()
+    {
+        await EnsureProfileAsync();
+
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath);
+
+        schemaResult.ExitCode.Should().Be(0, $"Schema generation StdErr: {schemaResult.StdErr}");
+
+        var zipPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath,
+            "--output-format", "json");
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        // JSON format outputs progress to stderr per output conventions
+        result.StdErr.Should().Contain("{");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Export_WithProfileOption_UsesSpecifiedProfile()
+    {
+        // Create profile WITHOUT calling auth select
+        var profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        // Generate schema using --profile (no profile is selected)
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath,
+            "--profile", profileName);
+
+        schemaResult.ExitCode.Should().Be(0, $"Schema generation StdErr: {schemaResult.StdErr}");
+
+        var zipPath = GenerateTempFilePath(".zip");
+
+        var result = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath,
+            "--profile", profileName);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task EnsureProfileAsync()
+    {
+        if (_profileName != null) return;
+
+        _profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", _profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", _profileName);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.LiveTests/Cli/DataExportCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataExportCommandE2ETests.cs
@@ -11,11 +11,6 @@ namespace PPDS.LiveTests.Cli;
 public class DataExportCommandE2ETests : CliE2ETestBase
 {
     /// <summary>
-    /// Unique identifier prefix for test artifacts to avoid conflicts.
-    /// </summary>
-    private readonly string _testPrefix = $"PPDS_E2EExport_{Guid.NewGuid():N}";
-
-    /// <summary>
     /// Profile name used across Tier 2 tests in this class.
     /// </summary>
     private string? _profileName;

--- a/tests/PPDS.LiveTests/Cli/DataImportCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataImportCommandE2ETests.cs
@@ -1,0 +1,298 @@
+using FluentAssertions;
+using PPDS.LiveTests.Infrastructure;
+using Xunit;
+
+namespace PPDS.LiveTests.Cli;
+
+/// <summary>
+/// E2E tests for ppds data import command.
+/// Imports data from CMT-format ZIP files into a Dataverse environment.
+/// Tests only run on .NET 8.0 since CLI is spawned with --framework net8.0.
+/// </summary>
+/// <remarks>
+/// Tier 1 tests validate option parsing and file existence (no credentials).
+/// Tier 2 tests perform a full schema -> export -> delete -> import round-trip
+/// against a live Dataverse environment and are marked DestructiveE2E.
+/// </remarks>
+public class DataImportCommandE2ETests : CliE2ETestBase
+{
+    /// <summary>
+    /// Unique identifier prefix for test records to avoid conflicts.
+    /// </summary>
+    private readonly string _testPrefix = $"PPDS_E2EImport_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Tracks account IDs created during tests for cleanup.
+    /// </summary>
+    private readonly List<Guid> _createdAccountIds = new();
+
+    /// <summary>
+    /// Profile name used across tests in this class.
+    /// </summary>
+    private string? _profileName;
+
+    /// <summary>
+    /// Import + export round-trips can take several minutes against a real environment.
+    /// </summary>
+    protected override TimeSpan CommandTimeout => TimeSpan.FromMinutes(5);
+
+    #region Tier 1: Validation tests (no credentials needed)
+
+    [CliE2EFact]
+    public async Task Import_MissingData_FailsWithError()
+    {
+        var result = await RunCliAsync("data", "import");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("--data", "required");
+    }
+
+    [CliE2EFact]
+    public async Task Import_DataFileNotFound_FailsWithError()
+    {
+        var nonexistentZip = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid():N}.zip");
+
+        var result = await RunCliAsync(
+            "data", "import",
+            "--data", nonexistentZip);
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("does not exist", "not found", "File");
+    }
+
+    [CliE2EFact]
+    public async Task Import_InvalidMode_FailsWithError()
+    {
+        // Provide a placeholder file so AcceptExistingOnly passes; we want the
+        // failure to come from the --mode enum parser, not from --data validation.
+        var zipPath = GenerateTempFilePath(".zip");
+        await File.WriteAllBytesAsync(zipPath, Array.Empty<byte>());
+
+        var result = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--mode", "Bogus");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("Bogus", "mode", "Create");
+    }
+
+    [CliE2EFact]
+    public async Task Import_InvalidBypassPlugins_FailsWithError()
+    {
+        var zipPath = GenerateTempFilePath(".zip");
+        await File.WriteAllBytesAsync(zipPath, Array.Empty<byte>());
+
+        var result = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--bypass-plugins", "notavalue");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("bypass-plugins", "sync", "async", "all");
+    }
+
+    [CliE2EFact]
+    public async Task Import_UserMappingNotFound_FailsWithError()
+    {
+        var zipPath = GenerateTempFilePath(".zip");
+        await File.WriteAllBytesAsync(zipPath, Array.Empty<byte>());
+
+        var result = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--user-mapping", "nonexistent.xml");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("user mapping", "not found", "does not exist");
+    }
+
+    #endregion
+
+    #region Tier 2: Live Dataverse round-trip tests
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Import_ValidZip_ImportsAccount()
+    {
+        await EnsureProfileAsync();
+
+        // 1. Create the account.
+        var accountName = $"{_testPrefix}_Import_{Guid.NewGuid():N}";
+        var accountId = await LiveTestHelpers.CreateAccountAsync(Configuration, accountName);
+        _createdAccountIds.Add(accountId);
+
+        // 2. Generate a schema scoped to just this account via filter.
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath,
+            "--filter", $"account:name eq '{accountName}'",
+            "--profile", _profileName!);
+        schemaResult.ExitCode.Should().Be(0, $"schema failed: {schemaResult.StdErr}");
+
+        // 3. Export the data using that schema.
+        var zipPath = GenerateTempFilePath(".zip");
+        var exportResult = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath,
+            "--profile", _profileName!);
+        exportResult.ExitCode.Should().Be(0, $"export failed: {exportResult.StdErr}");
+        File.Exists(zipPath).Should().BeTrue("export should have produced a zip");
+
+        // 4. Delete the account so the import can recreate it.
+        await LiveTestHelpers.DeleteAccountsAsync(Configuration, new[] { accountId });
+        _createdAccountIds.Remove(accountId);
+
+        // 5. Import the data back.
+        var importResult = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--mode", "Upsert",
+            "--profile", _profileName!);
+
+        importResult.ExitCode.Should().Be(0, $"import failed: {importResult.StdErr}");
+
+        // 6. Verify the account exists again, and re-track for cleanup.
+        var exists = await LiveTestHelpers.AccountExistsAsync(Configuration, accountId);
+        exists.Should().BeTrue("account should have been re-imported");
+
+        _createdAccountIds.Add(accountId);
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Import_JsonFormat_ProducesJsonOutput()
+    {
+        await EnsureProfileAsync();
+
+        // Mini round-trip: create -> schema -> export -> delete -> import (json)
+        var accountName = $"{_testPrefix}_ImportJson_{Guid.NewGuid():N}";
+        var accountId = await LiveTestHelpers.CreateAccountAsync(Configuration, accountName);
+        _createdAccountIds.Add(accountId);
+
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath,
+            "--filter", $"account:name eq '{accountName}'",
+            "--profile", _profileName!);
+        schemaResult.ExitCode.Should().Be(0, $"schema failed: {schemaResult.StdErr}");
+
+        var zipPath = GenerateTempFilePath(".zip");
+        var exportResult = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath,
+            "--profile", _profileName!);
+        exportResult.ExitCode.Should().Be(0, $"export failed: {exportResult.StdErr}");
+
+        await LiveTestHelpers.DeleteAccountsAsync(Configuration, new[] { accountId });
+        _createdAccountIds.Remove(accountId);
+
+        var importResult = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--output-format", "json",
+            "--profile", _profileName!);
+
+        importResult.ExitCode.Should().Be(0, $"import failed: {importResult.StdErr}");
+        // JSON format streams progress objects to stderr per output conventions
+        // (mirrors DataSchema_JsonFormat_OutputsProgress).
+        importResult.StdErr.Should().Contain("{");
+
+        _createdAccountIds.Add(accountId);
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Import_WithProfileOption_UsesSpecifiedProfile()
+    {
+        // Create profile but DO NOT auth select - rely solely on --profile.
+        var profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        // Set up data via the round-trip pattern, all driven through --profile.
+        var accountName = $"{_testPrefix}_ImportProf_{Guid.NewGuid():N}";
+        var accountId = await LiveTestHelpers.CreateAccountAsync(Configuration, accountName);
+        _createdAccountIds.Add(accountId);
+
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath,
+            "--filter", $"account:name eq '{accountName}'",
+            "--profile", profileName);
+        schemaResult.ExitCode.Should().Be(0, $"schema failed: {schemaResult.StdErr}");
+
+        var zipPath = GenerateTempFilePath(".zip");
+        var exportResult = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath,
+            "--profile", profileName);
+        exportResult.ExitCode.Should().Be(0, $"export failed: {exportResult.StdErr}");
+
+        await LiveTestHelpers.DeleteAccountsAsync(Configuration, new[] { accountId });
+        _createdAccountIds.Remove(accountId);
+
+        var importResult = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--profile", profileName);
+
+        importResult.ExitCode.Should().Be(0, $"import failed: {importResult.StdErr}");
+
+        _createdAccountIds.Add(accountId);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task EnsureProfileAsync()
+    {
+        if (_profileName != null) return;
+
+        _profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", _profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", _profileName);
+    }
+
+    public override async Task DisposeAsync()
+    {
+        // Clean up any test accounts that weren't deleted by tests
+        if (_createdAccountIds.Count > 0)
+        {
+            try
+            {
+                await LiveTestHelpers.DeleteAccountsAsync(Configuration, _createdAccountIds);
+            }
+            catch (Exception)
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        await base.DisposeAsync();
+    }
+
+    #endregion
+}

--- a/tests/PPDS.LiveTests/Cli/DataImportCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataImportCommandE2ETests.cs
@@ -97,11 +97,12 @@ public class DataImportCommandE2ETests : CliE2ETestBase
     {
         var zipPath = GenerateTempFilePath(".zip");
         await File.WriteAllBytesAsync(zipPath, Array.Empty<byte>());
+        var nonexistentMapping = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid():N}.xml");
 
         var result = await RunCliAsync(
             "data", "import",
             "--data", zipPath,
-            "--user-mapping", "nonexistent.xml");
+            "--user-mapping", nonexistentMapping);
 
         result.ExitCode.Should().NotBe(0);
         (result.StdOut + result.StdErr).Should().ContainAny("user mapping", "not found", "does not exist");
@@ -142,9 +143,11 @@ public class DataImportCommandE2ETests : CliE2ETestBase
         exportResult.ExitCode.Should().Be(0, $"export failed: {exportResult.StdErr}");
         File.Exists(zipPath).Should().BeTrue("export should have produced a zip");
 
-        // 4. Delete the account so the import can recreate it.
+        // 4. Delete the account so the import can recreate it. The id stays in
+        // _createdAccountIds — DeleteAccountsAsync ignores not-found, so cleanup
+        // is idempotent whether the import succeeds, fails, or this method
+        // throws before we can re-track the id.
         await LiveTestHelpers.DeleteAccountsAsync(Configuration, new[] { accountId });
-        _createdAccountIds.Remove(accountId);
 
         // 5. Import the data back.
         var importResult = await RunCliAsync(
@@ -155,11 +158,9 @@ public class DataImportCommandE2ETests : CliE2ETestBase
 
         importResult.ExitCode.Should().Be(0, $"import failed: {importResult.StdErr}");
 
-        // 6. Verify the account exists again, and re-track for cleanup.
+        // 6. Verify the account exists again (Upsert preserves primary key).
         var exists = await LiveTestHelpers.AccountExistsAsync(Configuration, accountId);
         exists.Should().BeTrue("account should have been re-imported");
-
-        _createdAccountIds.Add(accountId);
     }
 
     [CliE2EWithCredentials]
@@ -191,7 +192,6 @@ public class DataImportCommandE2ETests : CliE2ETestBase
         exportResult.ExitCode.Should().Be(0, $"export failed: {exportResult.StdErr}");
 
         await LiveTestHelpers.DeleteAccountsAsync(Configuration, new[] { accountId });
-        _createdAccountIds.Remove(accountId);
 
         var importResult = await RunCliAsync(
             "data", "import",
@@ -203,8 +203,6 @@ public class DataImportCommandE2ETests : CliE2ETestBase
         // JSON format streams progress objects to stderr per output conventions
         // (mirrors DataSchema_JsonFormat_OutputsProgress).
         importResult.StdErr.Should().Contain("{");
-
-        _createdAccountIds.Add(accountId);
     }
 
     [CliE2EWithCredentials]
@@ -244,7 +242,6 @@ public class DataImportCommandE2ETests : CliE2ETestBase
         exportResult.ExitCode.Should().Be(0, $"export failed: {exportResult.StdErr}");
 
         await LiveTestHelpers.DeleteAccountsAsync(Configuration, new[] { accountId });
-        _createdAccountIds.Remove(accountId);
 
         var importResult = await RunCliAsync(
             "data", "import",
@@ -252,8 +249,6 @@ public class DataImportCommandE2ETests : CliE2ETestBase
             "--profile", profileName);
 
         importResult.ExitCode.Should().Be(0, $"import failed: {importResult.StdErr}");
-
-        _createdAccountIds.Add(accountId);
     }
 
     #endregion

--- a/tests/PPDS.LiveTests/Cli/DataImportCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataImportCommandE2ETests.cs
@@ -129,7 +129,7 @@ public class DataImportCommandE2ETests : CliE2ETestBase
             "data", "schema",
             "--entities", "account",
             "--output", schemaPath,
-            "--filter", $"account:name eq '{accountName}'",
+            "--filter", $"account:name = '{accountName}'",
             "--profile", _profileName!);
         schemaResult.ExitCode.Should().Be(0, $"schema failed: {schemaResult.StdErr}");
 
@@ -179,7 +179,7 @@ public class DataImportCommandE2ETests : CliE2ETestBase
             "data", "schema",
             "--entities", "account",
             "--output", schemaPath,
-            "--filter", $"account:name eq '{accountName}'",
+            "--filter", $"account:name = '{accountName}'",
             "--profile", _profileName!);
         schemaResult.ExitCode.Should().Be(0, $"schema failed: {schemaResult.StdErr}");
 
@@ -229,7 +229,7 @@ public class DataImportCommandE2ETests : CliE2ETestBase
             "data", "schema",
             "--entities", "account",
             "--output", schemaPath,
-            "--filter", $"account:name eq '{accountName}'",
+            "--filter", $"account:name = '{accountName}'",
             "--profile", profileName);
         schemaResult.ExitCode.Should().Be(0, $"schema failed: {schemaResult.StdErr}");
 

--- a/tests/PPDS.LiveTests/Cli/DataMigrationWorkflowE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataMigrationWorkflowE2ETests.cs
@@ -54,7 +54,7 @@ public class DataMigrationWorkflowE2ETests : CliE2ETestBase
             "data", "schema",
             "--entities", "account",
             "--output", schemaPath,
-            "--filter", $"account:name eq '{name}'",
+            "--filter", $"account:name = '{name}'",
             "--profile", _profileName!);
 
         schemaResult.ExitCode.Should().Be(0, $"Schema generation failed: {schemaResult.StdErr}");
@@ -110,7 +110,7 @@ public class DataMigrationWorkflowE2ETests : CliE2ETestBase
             "data", "schema",
             "--entities", "account",
             "--output", schemaPath,
-            "--filter", $"account:name eq '{name}'",
+            "--filter", $"account:name = '{name}'",
             "--profile", _profileName!);
 
         schemaResult.ExitCode.Should().Be(0, $"Schema generation failed: {schemaResult.StdErr}");

--- a/tests/PPDS.LiveTests/Cli/DataMigrationWorkflowE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataMigrationWorkflowE2ETests.cs
@@ -1,0 +1,209 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.LiveTests.Infrastructure;
+using Xunit;
+
+namespace PPDS.LiveTests.Cli;
+
+/// <summary>
+/// End-to-end tests for the full data migration workflow:
+/// schema generation -> export -> import round-trip.
+/// Tests only run on .NET 8.0 since CLI is spawned with --framework net8.0.
+/// </summary>
+/// <remarks>
+/// These tests are marked [Trait("Category", "DestructiveE2E")] because they
+/// create and delete real Dataverse records as part of the round-trip.
+/// </remarks>
+public class DataMigrationWorkflowE2ETests : CliE2ETestBase
+{
+    /// <summary>
+    /// Unique identifier prefix for test records to avoid conflicts.
+    /// </summary>
+    private readonly string _testPrefix = $"PPDS_E2EWorkflow_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Tracks account IDs created during tests for cleanup.
+    /// </summary>
+    private readonly List<Guid> _createdAccountIds = new();
+
+    /// <summary>
+    /// Profile name used across tests in this class.
+    /// </summary>
+    private string? _profileName;
+
+    /// <summary>
+    /// The full round-trip pipeline runs three CLI invocations sequentially
+    /// (schema, export, import), so allow extra time.
+    /// </summary>
+    protected override TimeSpan CommandTimeout => TimeSpan.FromMinutes(5);
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task FullRoundTrip_SchemaExportImport_PreservesAccountData()
+    {
+        await EnsureProfileAsync();
+
+        // 1. Create a test account in Dataverse.
+        var name = $"{_testPrefix}_RoundTrip_{Guid.NewGuid():N}";
+        var accountId = await LiveTestHelpers.CreateAccountAsync(Configuration, name);
+        _createdAccountIds.Add(accountId);
+
+        // 2. Generate a filtered schema that targets only this account by name.
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath,
+            "--filter", $"account:name eq '{name}'",
+            "--profile", _profileName!);
+
+        schemaResult.ExitCode.Should().Be(0, $"Schema generation failed: {schemaResult.StdErr}");
+        File.Exists(schemaPath).Should().BeTrue("Schema file should be created");
+
+        // 3. Export data using the filtered schema.
+        var zipPath = GenerateTempFilePath(".zip");
+        var exportResult = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath,
+            "--profile", _profileName!);
+
+        exportResult.ExitCode.Should().Be(0, $"Export failed: {exportResult.StdErr}");
+        File.Exists(zipPath).Should().BeTrue("Export ZIP file should be created");
+        new FileInfo(zipPath).Length.Should().BeGreaterThan(0, "Export ZIP should have content");
+
+        // 4. Delete the source account so import has to recreate it.
+        await LiveTestHelpers.DeleteAccountsAsync(Configuration, new[] { accountId });
+        (await LiveTestHelpers.AccountExistsAsync(Configuration, accountId))
+            .Should().BeFalse("Account should have been deleted before import");
+
+        // 5. Import the exported data with Upsert mode.
+        var importResult = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--mode", "Upsert",
+            "--profile", _profileName!);
+
+        importResult.ExitCode.Should().Be(0, $"Import failed: {importResult.StdErr}");
+
+        // 6. Verify the account exists again with the same id (Upsert preserves primary key).
+        (await LiveTestHelpers.AccountExistsAsync(Configuration, accountId))
+            .Should().BeTrue("import should re-create with original id via Upsert");
+
+        // accountId remains in _createdAccountIds — DisposeAsync will clean up.
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task FullRoundTrip_UpsertMode_UpdatesExistingRecord()
+    {
+        await EnsureProfileAsync();
+
+        // 1. Create a test account with a known description.
+        var name = $"{_testPrefix}_Upsert_{Guid.NewGuid():N}";
+        var accountId = await CreateAccountWithDescriptionAsync(name, "ORIGINAL");
+
+        // 2. Generate a filtered schema. By default, schema includes all attributes
+        // for an entity, so the description column will be captured.
+        var schemaPath = GenerateTempFilePath(".xml");
+        var schemaResult = await RunCliAsync(
+            "data", "schema",
+            "--entities", "account",
+            "--output", schemaPath,
+            "--filter", $"account:name eq '{name}'",
+            "--profile", _profileName!);
+
+        schemaResult.ExitCode.Should().Be(0, $"Schema generation failed: {schemaResult.StdErr}");
+
+        // 3. Export the original record (description=ORIGINAL) to a ZIP.
+        var zipPath = GenerateTempFilePath(".zip");
+        var exportResult = await RunCliAsync(
+            "data", "export",
+            "--schema", schemaPath,
+            "--output", zipPath,
+            "--profile", _profileName!);
+
+        exportResult.ExitCode.Should().Be(0, $"Export failed: {exportResult.StdErr}");
+        File.Exists(zipPath).Should().BeTrue("Export ZIP file should be created");
+        new FileInfo(zipPath).Length.Should().BeGreaterThan(0, "Export ZIP should have content");
+
+        // 4. Modify the live record's description so we can verify Upsert restores it.
+        await UpdateAccountDescriptionAsync(accountId, "MODIFIED");
+
+        // 5. Verify the modification took effect before importing.
+        (await LiveTestHelpers.GetAccountDescriptionAsync(Configuration, accountId))
+            .Should().Be("MODIFIED", "live record should have been updated");
+
+        // 6. Import with Upsert to overwrite the modified record with the exported data.
+        var importResult = await RunCliAsync(
+            "data", "import",
+            "--data", zipPath,
+            "--mode", "Upsert",
+            "--profile", _profileName!);
+
+        importResult.ExitCode.Should().Be(0, $"Import failed: {importResult.StdErr}");
+
+        // 7. Verify Upsert restored the original description from the export.
+        (await LiveTestHelpers.GetAccountDescriptionAsync(Configuration, accountId))
+            .Should().Be("ORIGINAL", "Upsert should have restored the exported description");
+
+        // accountId remains in _createdAccountIds — DisposeAsync will clean up.
+    }
+
+    #region Helper Methods
+
+    private async Task EnsureProfileAsync()
+    {
+        if (_profileName != null) return;
+
+        _profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", _profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", _profileName);
+    }
+
+    private async Task<Guid> CreateAccountWithDescriptionAsync(string name, string description)
+    {
+        using var client = await LiveTestHelpers.CreateServiceClientAsync(Configuration);
+        var entity = new Entity("account")
+        {
+            ["name"] = name,
+            ["description"] = description
+        };
+        var id = client.Create(entity);
+        _createdAccountIds.Add(id);
+        return id;
+    }
+
+    private async Task UpdateAccountDescriptionAsync(Guid id, string description)
+    {
+        using var client = await LiveTestHelpers.CreateServiceClientAsync(Configuration);
+        client.Update(new Entity("account", id) { ["description"] = description });
+        await Task.CompletedTask;
+    }
+
+    public override async Task DisposeAsync()
+    {
+        if (_createdAccountIds.Count > 0)
+        {
+            try
+            {
+                await LiveTestHelpers.DeleteAccountsAsync(Configuration, _createdAccountIds);
+            }
+            catch (Exception)
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        await base.DisposeAsync();
+    }
+
+    #endregion
+}

--- a/tests/PPDS.LiveTests/Cli/DataMigrationWorkflowE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataMigrationWorkflowE2ETests.cs
@@ -185,7 +185,6 @@ public class DataMigrationWorkflowE2ETests : CliE2ETestBase
     {
         using var client = await LiveTestHelpers.CreateServiceClientAsync(Configuration);
         client.Update(new Entity("account", id) { ["description"] = description });
-        await Task.CompletedTask;
     }
 
     public override async Task DisposeAsync()


### PR DESCRIPTION
## Summary
- Add three new CLI E2E test files closing the data migration coverage gap from #104:
  - `DataExportCommandE2ETests` (10 tests: 7 validation + 3 live Dataverse)
  - `DataImportCommandE2ETests` (8 tests: 5 validation + 3 round-trip)
  - `DataMigrationWorkflowE2ETests` (2 full schema → export → import → verify round-trips, including Upsert restore-from-export)
- All Tier 2 tests are gated by `[CliE2EWithCredentials]` and skip cleanly without Dataverse credentials. Mutating tests carry `[Trait("Category", "DestructiveE2E")]`.
- Test cleanup tracks created accounts via `_createdAccountIds` and deletes them in `DisposeAsync`; `LiveTestHelpers.DeleteAccountsAsync` is idempotent so the id stays tracked across the in-test delete/import cycle.

Closes #104

## Test Plan
- [x] `dotnet build PPDS.sln -v q` — 0 errors
- [x] `dotnet test PPDS.sln --filter "Category!=Integration" -v q --no-build` — 0 failures (1058+ unit tests across all TFMs)
- [x] All 20 new tests discovered by xunit on net8.0
- [x] Built CLI Release/net8.0 and ran all 18 export+import tests: 12 Tier 1 PASSED against the real CLI binary, 6 Tier 2 SKIPPED cleanly without credentials
- [x] Workflow tests (2): both SKIP cleanly without credentials
- [ ] CI: Tier 2 tests will run live in CI where Dataverse credentials are configured

## Verification
- [x] /gates passed (build + tests + audit)
- [x] /verify completed (surfaces: cli)
- [x] /qa completed (surfaces: cli — recorded as N/A since no production CLI changes; verify already ran 12 new tests against real CLI binary)
- [x] /review completed — 2 CRITICAL + 2 IMPORTANT findings addressed in commit `683cb769e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
