### PR TITLE
release: v1.1

### DIFF
--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests for all credential providers (#133, #956).
 
 ### Fixed
-- Sovereign-cloud URL generation in `DataverseUrlBuilder` now correctly handles GCC High, DoD, and other sovereign clouds (#879, #947).
+- Sovereign-cloud Maker Portal and Flow Portal URLs in `CloudEndpoints` — added `GetMakerPortalUrl` and `GetFlowPortalUrl` with per-cloud URL tables (#879, #947).
 
 ## [1.0.0] - 2026-04-18
 

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-26
+
+### Added
+- BAP (Business Application Platform) environment discovery for service principals — environments can now be resolved by friendly name for SPN-authenticated profiles (#99, #956).
+- Unit tests for all credential providers (#133, #956).
+
+### Fixed
+- Sovereign-cloud URL generation in `DataverseUrlBuilder` now correctly handles GCC High, DoD, and other sovereign clouds (#879, #947).
+
 ## [1.0.0] - 2026-04-18
 
 First stable release. Consolidates features developed across the `1.0.0-beta.1` through `1.0.0-beta.8` series. Targets `net8.0`, `net9.0`, `net10.0`.

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-26
+
+### Added
+- **Web resources** `pull` and `push` commands with content-hash tracking for change detection (#950).
+- **`data schema --filter`** option to filter schema generation to specific entities using SQL-like expressions (#502, #948).
+- **TUI per-tab profile switching** — individual tabs can target different Dataverse profiles (#927, #935).
+- **Diagnostic markers** for SQL and FetchXML syntax errors surfaced via daemon RPC to the extension (#650, #966).
+- **Metadata Browser** entity configuration tab and global optionset details in daemon endpoints (#924).
+- Unit tests for query models and CLI query commands (#945).
+- RPC contract tests for the Extension-CLI daemon protocol (#672, #966).
+
+### Changed
+- Per-panel profile and environment scoping — each extension panel tracks its own active context via daemon RPC (#887, #888, #903, #936).
+
+### Fixed
+- Solutions panel no longer shows fabricated "All Solutions" entry; component type names auto-synced from metadata (#890, #892, #916).
+- Added direct `Microsoft.Data.SqlClient` reference — fixes TDS endpoint assembly-not-found error (#889, #905).
+- Sovereign-cloud URL hardcoding in metadata mutation hooks (#870, #947).
+
 ## [1.0.0] - 2026-04-18
 
 First stable release. Consolidates features developed across the `1.0.0-beta.1` through `1.0.0-beta.14` series.

--- a/src/PPDS.Extension/CHANGELOG.md
+++ b/src/PPDS.Extension/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-26
+
+Stable-channel release (even minor per odd/even convention). Post-GA polish across all panels.
+
+### Added
+- **Diagnostic markers** — Monaco squiggles for SQL and FetchXML syntax errors in notebooks (#650, #966).
+- **Metadata Browser** entity configuration tab and global optionset details (#924).
+- **Per-panel profile and environment scoping** — each panel tracks its own active Dataverse context independently (#887, #888, #903, #936).
+
+### Changed
+- Standardized toolbar layout and search bar placement across all panels (#898, #899, #933).
+
+### Fixed
+- Profiles tree view no longer stuck in infinite spinner — added RPC timeouts and error states (#904, #909).
+- Sync Deployment Settings no longer hangs on large environments (#893, #908).
+- Import Jobs panel no longer opens two XML documents on single click (#891, #919).
+- Plugin Traces toggle now shows visual feedback when changing trace settings (#895, #919).
+- Environment Variables and Connection References "Active only / All" toggle clarified (#894, #919).
+- Solutions panel no longer shows fabricated "All Solutions" entry; component type names auto-synced (#890, #892, #916).
+- Solution filter state now syncs to webview on panel open (#902, #918).
+- Plugin Registration toolbar buttons and tree collapse toggles styled correctly (#896, #897, #922).
+- Plugin Registration help link updated to main docs page (#900, #921).
+
 ## [1.0.0] - 2026-04-18
 
 > Enjoying PPDS v1.0? Please [leave a review on the Marketplace](https://marketplace.visualstudio.com/items?itemName=JoshSmithXRM.power-platform-developer-suite&ssr=false#review-details) — reviews are the single biggest conversion signal for new users.

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -2,7 +2,7 @@
   "name": "power-platform-developer-suite",
   "displayName": "Power Platform Developer Suite",
   "description": "Power Platform and Dataverse developer suite for VS Code — SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "publisher": "JoshSmithXRM",
   "preview": false,
   "qna": false,

--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-26
+
+### Added
+- `--filter` option for `data schema` command — filter schema generation to specific entities using SQL-like expressions (#502, #948).
+
 ## [1.0.0] - 2026-04-18
 
 First stable release. Consolidates features developed across the `1.0.0-beta.1` through `1.0.0-beta.8` series. Targets `net8.0`, `net9.0`, `net10.0`.


### PR DESCRIPTION
## Summary

Coordinated v1.1 minor release — CHANGELOGs and extension version bump.

**Packages being released:**

| Package | Version | Key Changes |
|---------|---------|-------------|
| PPDS.Auth | 1.0.0 → 1.1.0 | BAP environment discovery for SPNs, sovereign-cloud URL fix |
| PPDS.Cli | 1.0.0 → 1.1.0 | Web resources pull/push, data schema --filter, TUI profile switching, diagnostic markers, 3 fixes |
| PPDS.Extension | 1.0.0 → 1.2.0 | Per-panel scoping, entity config tab, toolbar standardization, diagnostic markers, 9 fixes |
| PPDS.Migration | 1.0.0 → 1.1.0 | Data schema --filter option |

**Packages unchanged (no new tags):** Dataverse, Mcp, Plugins, Query — zero code changes since 1.0.0.

**Extension version is 1.2.0** (not 1.1.0) per the odd/even minor convention: odd = pre-release channel, even = stable.

## After merge

Push per-package tags from the merge commit:
```
Auth-v1.1.0, Cli-v1.1.0, Migration-v1.1.0, Extension-v1.2.0
```

Plus unified milestone tag `v1.1.0`.

## Test plan

- [ ] Review all four CHANGELOGs for accuracy and completeness
- [ ] Verify extension package.json version is 1.2.0
- [ ] Confirm no CHANGELOG entries for unchanged packages (Dataverse, Mcp, Plugins, Query)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)